### PR TITLE
updated GeoJSON Normative References for WasteManagement

### DIFF
--- a/WasteManagement/WasteContainer/doc/spec.md
+++ b/WasteManagement/WasteContainer/doc/spec.md
@@ -6,37 +6,37 @@ A waste container.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `WasteContainer`.
 
-+ `location` : Container's location represented by a GeoJSON Point. 
++ `location` : Container's location represented by a GeoJSON Point.
     + Attribute type: `geo:json`.
-    + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
+    + Normative References: [https://datatracker.ietf.org/wg/geojson/documents/](https://datatracker.ietf.org/wg/geojson/documents/)
     + Mandatory if `address` is not present.
-    
-+ `address`: Civic address where the container is located. 
+
++ `address`: Civic address where the container is located.
     + Normative References: [https://schema.org/address](https://schema.org/address)
-    + Mandatory if `location` is not present. 
+    + Mandatory if `location` is not present.
 
 + `fillingLevel` : Filling level of the container (percentage, expressed in parts per one).
 When the container is full it must be equal to `1.0`. When the container is empty it must be equal to `0.0`. If it is not
-possible to determine the current filling level it must be equal to `null`. 
+possible to determine the current filling level it must be equal to `null`.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
         + `dateUpdated`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
-    + Allowed values: Interval [0,1]. 
+    + Allowed values: Interval [0,1].
     + Optional
-    
-+ `temperature` : Temperature inside the container. 
+
++ `temperature` : Temperature inside the container.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
         + `dateUpdated`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Celsius Degrees.
     + Optional
-    
+
 + `methaneConcentration` : Methane (CH4) concentration inside the container.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
@@ -59,13 +59,13 @@ possible to determine the current filling level it must be equal to `null`.
 
 + `storedWasteCode` : As per the regulation, waste codes which precisely identifies waste origin and kind.
     + Attribute type: List of [Text](http://schema.org/Text)
-    + Allowed values: Depend on the target regulation. For Europe, check [Europe's List of Waste](http://ec.europa.eu/environment/waste/framework/list.htm). 
+    + Allowed values: Depend on the target regulation. For Europe, check [Europe's List of Waste](http://ec.europa.eu/environment/waste/framework/list.htm).
     + Optional
 
 + `refWasteContainerModel` : Container's model.
     + Attribute type: Reference to a [WasteContainerModel](../../WasteContainerModel/doc/spec.md) entity.
     + Optional
-    
+
 + `serialNumber` : Serial number of the container.
     + Normative References: [https://schema.org/serialNumber](https://schema.org/serialNumber)
     + Optional
@@ -73,11 +73,11 @@ possible to determine the current filling level it must be equal to `null`.
 + `regulation` : Regulation under which the container is operating.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Optional
-    
-+ `responsible` : Responsible for the container, i.e. entity in charge of actuating (emptying, collecting etc.). 
+
++ `responsible` : Responsible for the container, i.e. entity in charge of actuating (emptying, collecting etc.).
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
-    
+
 + `owner` : Container's owner.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
@@ -85,15 +85,15 @@ possible to determine the current filling level it must be equal to `null`.
 + `dateServiceStarted` : Date at which the container started giving service.
     + Attribute Type: [Date](http://schema.org/Date)
     + Optional
-    
+
 + `dateLastEmptying` : Timestamp which represents when the container was emptied last time.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `nextActuationDeadline` : Deadline for next actuation to be performed (emptying, picking up, etc.).
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `actuationHours` :  Hours suitable for performing actuations over the container.
     + Attribute Type: [Text](http://schema.org/Text)
     + Normative References: Value must be compliant with [https://schema.org/openingHours](https://schema.org/openingHours)
@@ -105,11 +105,11 @@ possible to determine the current filling level it must be equal to `null`.
 + `nextCleaningDeadline` : Deadline for next cleaning.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
-+ `containerIsle` : Isle where the container is placed. 
+
++ `containerIsle` : Isle where the container is placed.
     + Attribute Type: Reference to a [WasteContainerIsle](../../WasteContainerIsle/doc/spec.md) entity.
     + Optional
-    
+
 + `category` : Container's category.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed Values:
@@ -118,7 +118,7 @@ possible to determine the current filling level it must be equal to `null`.
         + `underground`. Container is placed underground.
         + `ground`. Container is placed at ground level.
         + `portable`. Container can be moved around a certain extent.
-        + Any other value which captures an aspect not covered by those referred above. 
+        + Any other value which captures an aspect not covered by those referred above.
 
 + `status` : Container's status from the point of view of safety.
     + Attribute type: [Text](https://schema.org/Text)
@@ -141,7 +141,7 @@ possible to determine the current filling level it must be equal to `null`.
         + `providerName` : Sensor and/or service provider's name
              + Type: [String](https://schema.org/Number)
     + Optional
-    
+
 + `color` : Container's color
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed Values:
@@ -153,25 +153,25 @@ possible to determine the current filling level it must be equal to `null`.
 + `image` : A URL containing a photo of the container.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
-    
-+ `description` : Description about the container. 
+
++ `description` : Description about the container.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
 
 + `annotations` : A field reserved for annotations (incidences, remarks, etc.).
     + Attribute type: List of [Text](https://schema.org/Text)
     + Optional
-    
+
 + `area` : Higher level area to which the container belongs to. It can be used to group containers per
 responsible, district, neighbourhood, etc.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-    
+
 + `dateUpdated` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 
-  
+
 ## Examples of use
 
     {
@@ -196,4 +196,4 @@ responsible, district, neighbourhood, etc.
 
 ## Open issues
 
-* Sensor data probably should be separated to a different entity. 
+* Sensor data probably should be separated to a different entity.

--- a/WasteManagement/WasteContainer/doc/spec.md
+++ b/WasteManagement/WasteContainer/doc/spec.md
@@ -6,37 +6,37 @@ A waste container.
 
 ## Data Model
 
-+ `id` : Unique identifier.
++ `id` : Unique identifier. 
 
 + `type` : Entity type. It must be equal to `WasteContainer`.
 
-+ `location` : Container's location represented by a GeoJSON Point.
++ `location` : Container's location represented by a GeoJSON Point. 
     + Attribute type: `geo:json`.
-    + Normative References: [https://datatracker.ietf.org/wg/geojson/documents/](https://datatracker.ietf.org/wg/geojson/documents/)
+    + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not present.
-
-+ `address`: Civic address where the container is located.
+    
++ `address`: Civic address where the container is located. 
     + Normative References: [https://schema.org/address](https://schema.org/address)
-    + Mandatory if `location` is not present.
+    + Mandatory if `location` is not present. 
 
 + `fillingLevel` : Filling level of the container (percentage, expressed in parts per one).
 When the container is full it must be equal to `1.0`. When the container is empty it must be equal to `0.0`. If it is not
-possible to determine the current filling level it must be equal to `null`.
+possible to determine the current filling level it must be equal to `null`. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
         + `dateUpdated`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
-    + Allowed values: Interval [0,1].
+    + Allowed values: Interval [0,1]. 
     + Optional
-
-+ `temperature` : Temperature inside the container.
+    
++ `temperature` : Temperature inside the container. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
         + `dateUpdated`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Celsius Degrees.
     + Optional
-
+    
 + `methaneConcentration` : Methane (CH4) concentration inside the container.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
@@ -59,13 +59,13 @@ possible to determine the current filling level it must be equal to `null`.
 
 + `storedWasteCode` : As per the regulation, waste codes which precisely identifies waste origin and kind.
     + Attribute type: List of [Text](http://schema.org/Text)
-    + Allowed values: Depend on the target regulation. For Europe, check [Europe's List of Waste](http://ec.europa.eu/environment/waste/framework/list.htm).
+    + Allowed values: Depend on the target regulation. For Europe, check [Europe's List of Waste](http://ec.europa.eu/environment/waste/framework/list.htm). 
     + Optional
 
 + `refWasteContainerModel` : Container's model.
     + Attribute type: Reference to a [WasteContainerModel](../../WasteContainerModel/doc/spec.md) entity.
     + Optional
-
+    
 + `serialNumber` : Serial number of the container.
     + Normative References: [https://schema.org/serialNumber](https://schema.org/serialNumber)
     + Optional
@@ -73,11 +73,11 @@ possible to determine the current filling level it must be equal to `null`.
 + `regulation` : Regulation under which the container is operating.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Optional
-
-+ `responsible` : Responsible for the container, i.e. entity in charge of actuating (emptying, collecting etc.).
+    
++ `responsible` : Responsible for the container, i.e. entity in charge of actuating (emptying, collecting etc.). 
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
-
+    
 + `owner` : Container's owner.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
@@ -85,15 +85,15 @@ possible to determine the current filling level it must be equal to `null`.
 + `dateServiceStarted` : Date at which the container started giving service.
     + Attribute Type: [Date](http://schema.org/Date)
     + Optional
-
+    
 + `dateLastEmptying` : Timestamp which represents when the container was emptied last time.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Optional
-
+    
 + `nextActuationDeadline` : Deadline for next actuation to be performed (emptying, picking up, etc.).
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Optional
-
+    
 + `actuationHours` :  Hours suitable for performing actuations over the container.
     + Attribute Type: [Text](http://schema.org/Text)
     + Normative References: Value must be compliant with [https://schema.org/openingHours](https://schema.org/openingHours)
@@ -105,11 +105,11 @@ possible to determine the current filling level it must be equal to `null`.
 + `nextCleaningDeadline` : Deadline for next cleaning.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Optional
-
-+ `containerIsle` : Isle where the container is placed.
+    
++ `containerIsle` : Isle where the container is placed. 
     + Attribute Type: Reference to a [WasteContainerIsle](../../WasteContainerIsle/doc/spec.md) entity.
     + Optional
-
+    
 + `category` : Container's category.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed Values:
@@ -118,7 +118,7 @@ possible to determine the current filling level it must be equal to `null`.
         + `underground`. Container is placed underground.
         + `ground`. Container is placed at ground level.
         + `portable`. Container can be moved around a certain extent.
-        + Any other value which captures an aspect not covered by those referred above.
+        + Any other value which captures an aspect not covered by those referred above. 
 
 + `status` : Container's status from the point of view of safety.
     + Attribute type: [Text](https://schema.org/Text)
@@ -141,7 +141,7 @@ possible to determine the current filling level it must be equal to `null`.
         + `providerName` : Sensor and/or service provider's name
              + Type: [String](https://schema.org/Number)
     + Optional
-
+    
 + `color` : Container's color
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed Values:
@@ -153,25 +153,25 @@ possible to determine the current filling level it must be equal to `null`.
 + `image` : A URL containing a photo of the container.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
-
-+ `description` : Description about the container.
+    
++ `description` : Description about the container. 
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
 
 + `annotations` : A field reserved for annotations (incidences, remarks, etc.).
     + Attribute type: List of [Text](https://schema.org/Text)
     + Optional
-
+    
 + `area` : Higher level area to which the container belongs to. It can be used to group containers per
 responsible, district, neighbourhood, etc.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-
+    
 + `dateUpdated` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 
-
+  
 ## Examples of use
 
     {
@@ -196,4 +196,4 @@ responsible, district, neighbourhood, etc.
 
 ## Open issues
 
-* Sensor data probably should be separated to a different entity.
+* Sensor data probably should be separated to a different entity. 

--- a/WasteManagement/WasteContainerIsle/doc/spec.md
+++ b/WasteManagement/WasteContainerIsle/doc/spec.md
@@ -2,46 +2,46 @@
 
 ## Description
 
-A geographical area which keeps one or more waste containers. 
+A geographical area which keeps one or more waste containers.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
++ `id` : Unique identifier.
 
-+ `type` : Entity type. It must be equal to `WasteContainerIsle`. 
++ `type` : Entity type. It must be equal to `WasteContainerIsle`.
 
 + `location` : Location of the isle represented by a GeoJSON Polygon.
     + Attribute type: `geo:json`.
-    + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
+    + Normative References: [https://datatracker.ietf.org/wg/geojson/documents/](https://datatracker.ietf.org/wg/geojson/documents/)
     + Mandatory
-  
-+ `address` : Civic address where the isle is located. 
+
++ `address` : Civic address where the isle is located.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Optional
- 
+
 + `name` : Name given to the isle
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Optional
 
-+ `description` : Description about the isle. 
++ `description` : Description about the isle.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `insertHolesNumber` : Number of insert holes the isle has.
     + Attribute type: [Number](https://schema.org/Number).
     + Optional
-    
+
 + `features` : A list of features provided by the isle.
     + Attribute type: List of [Text](http://schema.org/Text).
     + Allowed values:
         + `containerFix`. Allows to fix containers to a permanent position.
         + `fenced`. The isle is properly fenced.
-        + `underground`. The isle allows to hold buried containers. 
+        + `underground`. The isle allows to hold buried containers.
         + Any other value meaningful to the application.
     + Optional
 
 + `containers` : List of containers present in the isle.
-    + Attribute type: List of references to [WasteContainer](../../WasteContainer/doc/spec.md) entities. 
+    + Attribute type: List of references to [WasteContainer](../../WasteContainer/doc/spec.md) entities.
     + Allowed values. Container's id.
     + Optional
 
@@ -49,7 +49,7 @@ A geographical area which keeps one or more waste containers.
 responsible, district, neighbourhood, etc.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-    
+
 + `dateUpdated` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
@@ -83,9 +83,9 @@ responsible, district, neighbourhood, etc.
       "features": ["underground"],
       "name": "Dr. Fleming 12, Esquina Manuel Paez Xaramillo",
       "description": "Container isle located downtown",
-      "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"] 
+      "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"]
     }
-    
+
 ## Test it with a real service
 
 T.B.D.

--- a/WasteManagement/WasteContainerIsle/doc/spec.md
+++ b/WasteManagement/WasteContainerIsle/doc/spec.md
@@ -2,46 +2,46 @@
 
 ## Description
 
-A geographical area which keeps one or more waste containers.
+A geographical area which keeps one or more waste containers. 
 
 ## Data Model
 
-+ `id` : Unique identifier.
++ `id` : Unique identifier. 
 
-+ `type` : Entity type. It must be equal to `WasteContainerIsle`.
++ `type` : Entity type. It must be equal to `WasteContainerIsle`. 
 
 + `location` : Location of the isle represented by a GeoJSON Polygon.
     + Attribute type: `geo:json`.
-    + Normative References: [https://datatracker.ietf.org/wg/geojson/documents/](https://datatracker.ietf.org/wg/geojson/documents/)
+    + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
-
-+ `address` : Civic address where the isle is located.
+  
++ `address` : Civic address where the isle is located. 
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Optional
-
+ 
 + `name` : Name given to the isle
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Optional
 
-+ `description` : Description about the isle.
++ `description` : Description about the isle. 
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-
+    
 + `insertHolesNumber` : Number of insert holes the isle has.
     + Attribute type: [Number](https://schema.org/Number).
     + Optional
-
+    
 + `features` : A list of features provided by the isle.
     + Attribute type: List of [Text](http://schema.org/Text).
     + Allowed values:
         + `containerFix`. Allows to fix containers to a permanent position.
         + `fenced`. The isle is properly fenced.
-        + `underground`. The isle allows to hold buried containers.
+        + `underground`. The isle allows to hold buried containers. 
         + Any other value meaningful to the application.
     + Optional
 
 + `containers` : List of containers present in the isle.
-    + Attribute type: List of references to [WasteContainer](../../WasteContainer/doc/spec.md) entities.
+    + Attribute type: List of references to [WasteContainer](../../WasteContainer/doc/spec.md) entities. 
     + Allowed values. Container's id.
     + Optional
 
@@ -49,7 +49,7 @@ A geographical area which keeps one or more waste containers.
 responsible, district, neighbourhood, etc.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-
+    
 + `dateUpdated` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
@@ -83,9 +83,9 @@ responsible, district, neighbourhood, etc.
       "features": ["underground"],
       "name": "Dr. Fleming 12, Esquina Manuel Paez Xaramillo",
       "description": "Container isle located downtown",
-      "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"]
+      "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"] 
     }
-
+    
 ## Test it with a real service
 
 T.B.D.


### PR DESCRIPTION
Dear team,

I suggest the following change on the basis of the recently released RFC 7946 for GeoJSON format by the IETF (2016-08-10): https://datatracker.ietf.org/wg/geojson/documents/

In the coming months GeoJSON format probably already become standard, so there will be new changes. I think it's better to put the link to IETF datatracker (instead a direct link to last documents) where is the status of the format and the link to the last document.

I did not change any more that line 15 from both files but Git have been tracked as changes (and there are no more changes at all) the change of tabs for spaces (or something like that).

Cayetano Benavent,
GEOGRAPHICA