### PR TITLE
`dateUpdated`  --> `timestamp`

### DIFF
--- a/IssueTracking/Open311_ServiceType/doc/spec.md
+++ b/IssueTracking/Open311_ServiceType/doc/spec.md
@@ -52,7 +52,7 @@ FIWARE / OASC recommends the following additional fields as an extension to the 
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 
-+ `dateUpdated` : Last update date of this service type.
++ `dateModified` : Last update date of this service type.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 

--- a/KeyPerformanceIndicator/doc/spec.md
+++ b/KeyPerformanceIndicator/doc/spec.md
@@ -96,7 +96,7 @@ Example `KPI-2016-2018-Incidences-Street`.
 + `currentStanding` : The KPI's current standing as per its `kpiValue`.
     + Attribute type: [Text](http://schema.org/Text)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Allowed values: one Of (`very good`, `good`, `fair`, `bad`, `very bad`)
     + Optional
@@ -104,7 +104,7 @@ Example `KPI-2016-2018-Incidences-Street`.
 + `kpiValue` :
     + Attribute type: It can be of any type. 
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Mandatory
     
@@ -120,7 +120,7 @@ Example `KPI-2016-2018-Incidences-Street`.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
       
-+ `dateUpdated` : Last update date of the KPI data. This can be different than the last update date of the KPI's value.
++ `dateModified` : Last update date of the KPI data. This can be different than the last update date of the KPI's value.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
     
@@ -159,7 +159,7 @@ hint which can help to identify the KPI coverage.
       },
       "calculationMethod": "automatic",
       "calculationFrequency": "monthly",
-      "dateUpdated": "2016-06-29T15:59:09.224Z",
+      "dateModified": "2016-06-29T15:59:09.224Z",
       "dateNextCalculation": "2016-07-31",
       "address": {
         "addressLocality": "Ciudad",

--- a/Parking/ParkingSpot/doc/spec.md
+++ b/Parking/ParkingSpot/doc/spec.md
@@ -42,7 +42,7 @@ Thus, an entity of type `ParkingSpot` cannot exist without a containing entity o
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed Values: one Of (`occupied`, `free`, `closed`, `unknown`)
     + Metadata:
-        + `dateUpdated` : Timestamp which reflects the date when the attribute value was obtained. 
+        + `timestamp` : Timestamp which reflects the date when the attribute value was obtained. 
               + Type: [DateTime](https://schema.org/DateTime)
               + Optional
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant)

--- a/StreetLighting/Streetlight/doc/spec.md
+++ b/StreetLighting/Streetlight/doc/spec.md
@@ -44,14 +44,14 @@ Typically it will contain an identifier that will allow to obtain more informati
     + Allowed values: one Of (`ok`, `defectiveLamp`, `columnIssue`, `brokenLantern`)
         + Or any other value meaningful to the application and not covered by the values above. 
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Mandatory
 
 + `powerState` : Streetlight's power state.
     + Attribute type: [Text](http://schema.org/Text)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Allowed values: one Of (`on`, `off`, `low`, `bootingUp`)
     + Optional
@@ -63,21 +63,21 @@ Typically it will contain an identifier that will allow to obtain more informati
 + `dateLastLampChange` : Timestamp of the last change of lamp made. If `null` it will mean that the lamp has never been changed. 
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
 + `dateLastSwitchingOn` : Timestamp of the last switching on.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
 + `dateLastSwitchingOff` : Timestamp of the last switching off.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
@@ -122,7 +122,7 @@ of this property are wall-mounted streetlights.
     + Attribute Type: [Number](http://schema.org/Number)
     + Allowed values: A number between 0 and 1.
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     

--- a/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -102,7 +102,7 @@ responsible, district, neighbourhood, etc.
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: Kilowatts per hour (Kwh).
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
@@ -110,7 +110,7 @@ responsible, district, neighbourhood, etc.
     + Attribute type: [Number](https://schema.org/Number)
     + Default currency: Euros. (Other currencies might be expressed using a metadata attribute)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
@@ -119,7 +119,7 @@ since the metering start date (`dateMeteringStarted`).
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: KiloVolts-Ampere-Reactive per hour (Kvar).
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
@@ -131,7 +131,7 @@ since the metering start date (`dateMeteringStarted`).
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: Kilowatts per hour.
     + Attribute metadata:
-        + `dateUpdated`: Timestamp which reflects the date and time at which the referred reading was obtained.
+        + `timestamp`: Timestamp which reflects the date and time at which the referred reading was obtained.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
@@ -148,7 +148,7 @@ since the metering start date (`dateMeteringStarted`).
     + Attribute Type: [Number](http://schema.org/Number)
     + Default unit: KiloWatts. 
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
@@ -156,7 +156,7 @@ since the metering start date (`dateMeteringStarted`).
     + Attribute Type: [Number](http://schema.org/Number)
     + Default unit: KiloVolts-Ampere-Reactive (Kvar). 
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
@@ -165,7 +165,7 @@ by subproperties which name will be equal to the name of each of the alternating
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: Kilowatts
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
@@ -175,7 +175,7 @@ current phases, typically R, S, T.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: KiloVolts-Ampere-Reactive (Kvar)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional    
        
@@ -183,7 +183,7 @@ current phases, typically R, S, T.
     + Attribute Type: [Number](http://schema.org/Number)
     + Allowed values: A number between -1 and 1.
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
@@ -191,7 +191,7 @@ current phases, typically R, S, T.
     + Attribute Type: [Number](http://schema.org/Number)
     + Allowed values: A number between -1 and 1.
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
    
@@ -201,7 +201,7 @@ will be equal to the phase name, typically `R`, `S`, `T`.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: Ampers
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
@@ -211,7 +211,7 @@ will be equal to the phase name, typically `R`, `S`, `T`.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: Volts
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 

--- a/StreetLighting/StreetlightGroup/doc/spec.md
+++ b/StreetLighting/StreetlightGroup/doc/spec.md
@@ -22,7 +22,7 @@ responsible, district, neighbourhood, etc.
 + `powerState` : Streetlight group's power state.
     + Attribute type: [Text](http://schema.org/Text)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Allowed values: one Of (`on`, `off`, `low`, `bootingUp`)
     + Optional
@@ -34,14 +34,14 @@ responsible, district, neighbourhood, etc.
 + `dateLastSwitchingOn` : Timestamp of the last switching on.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
 + `dateLastSwitchingOff` : Timestamp of the last switching off.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
@@ -55,7 +55,7 @@ responsible, district, neighbourhood, etc.
         + `hours` : Hours. 
             + Normative References: Value must be compliant with [https://schema.org/openingHours](https://schema.org/openingHours)
     + Attribute metadata:
-        + `dateUpdated` : Timestamp when the last update of the attribute happened.
+        + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
         
@@ -63,7 +63,7 @@ responsible, district, neighbourhood, etc.
     + Attribute Type: List of [Text](http://schema.org/Text)
     + Allowed values: (`night-ON`, `night-OFF`, `night-LOW`, `always-ON`, `day-ON`, `day-OFF`, `day-LOW`)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
     
@@ -71,14 +71,14 @@ responsible, district, neighbourhood, etc.
     + Attribute Type: [Number](http://schema.org/Number)
     + Allowed values: A number between 0 and 1.
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
         
 + `activeProgramId` : Identifier of the active program for this streetlight group.
     + Attribute type: [Text](https://schema.org/Text)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional 
     

--- a/WasteManagement/WasteContainer/doc/spec.md
+++ b/WasteManagement/WasteContainer/doc/spec.md
@@ -24,7 +24,7 @@ When the container is full it must be equal to `1.0`. When the container is empt
 possible to determine the current filling level it must be equal to `null`. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant)
         saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
@@ -37,7 +37,7 @@ to keep backwards compatibility with current FIWARE reference implementations.
 + `cargoWeight` : Weight of the container load.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant) saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
 to keep backwards compatibility with current FIWARE reference implementations. 
@@ -50,7 +50,7 @@ to keep backwards compatibility with current FIWARE reference implementations.
 + `temperature` : Temperature inside the container. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant)
         saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
@@ -63,7 +63,7 @@ to keep backwards compatibility with current FIWARE reference implementations.
 + `methaneConcentration` : Methane (CH4) concentration inside the container.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant)
         saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
@@ -161,7 +161,7 @@ entities of type `WasteContainerIsle` are not being modelled specifically. Other
         + `dropped`. Container has been dropped for some reason.
         + `moved`. Container has been moved from its regular position and has not come back.
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant)
         saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
@@ -216,7 +216,7 @@ It must be equal to `1.0` when battery is full. `0.0` when battery ìs empty.
     + Type: [Number](https://schema.org/Number)
     + Allowed values: Interval [0,1]
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant)
         saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
@@ -232,7 +232,7 @@ to keep backwards compatibility with current FIWARE reference implementations.
 + `deviceState` : State of the principal IoT device which monitors this container. Attribute value can depend on the device provider. 
     + Type: [Text](https://schema.org/Text)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
         + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant) saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
 to keep backwards compatibility with current FIWARE reference implementations. 

--- a/WaterQuality/WaterQualityObserved/doc/spec.md
+++ b/WaterQuality/WaterQualityObserved/doc/spec.md
@@ -155,7 +155,7 @@ Water Quality data model is intended to represent water quality parameters at a 
     + Default unit: milligrams per liter (mg/L).
     + Optional		
 	 
-+ `timestamp` : Last update timestamp of this entity
++ `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 

--- a/WaterQuality/WaterQualityObserved/doc/spec.md
+++ b/WaterQuality/WaterQualityObserved/doc/spec.md
@@ -22,7 +22,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `temperature` : Temperature. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Celsius Degrees.
     + Optional
@@ -30,7 +30,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `conductivity` : Electrical Conductivity. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Siemens per meter (S/m).
     + Optional	
@@ -38,7 +38,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `conductance` : Specific Conductance. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Siemens per meter at 25 ºC (S/m).
     + Optional	
@@ -46,7 +46,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `tss` : Total suspended solids. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: milligrams per liter (mg/L).
     + Optional		
@@ -54,7 +54,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `tds` : Total dissolved solids. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: milligrams per liter (mg/L).
     + Optional	
@@ -62,7 +62,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `turbidity` : Amount of light scattered by particles in the water column. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Formazin Turbidity Unit (FTU).
     + Optional	
@@ -70,7 +70,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `salinity` : Amount of salts dissolved in water. 
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Parts per thousand (ppt).
     + Optional		
@@ -78,7 +78,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `pH` : acidity or basicity of an aqueous solution.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: Negative of the logarithm to base 10 of the activity of the hydrogen ion.
     + Optional
@@ -86,7 +86,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `orp` : Oxidation-Reduction potential.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: millivolts (mV).
     + Optional
@@ -94,7 +94,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `O2` : Level of free, non-compound oxygen present.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: milligrams per liter (mg/L).
     + Optional	
@@ -102,7 +102,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `Chla` : Concentration of chlorophyll A.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: micrograms per liter.
     + Optional		
@@ -110,7 +110,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `PE` : Concentration of pigment phycoerythrin which can be measured to estimate cyanobacteria concentrations specifically.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: micrograms per liter.
     + Optional	
@@ -118,7 +118,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `PC` : Concentration of pigment phycocyanin which can be measured to estimate cyanobacteria concentrations specifically.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: micrograms per liter.
     + Optional		
@@ -126,7 +126,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `NH4` : Concentration of ammonium.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: milligrams per liter (mg/L).
     + Optional	
@@ -134,7 +134,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `NH3` : Concentration of ammonia.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: milligrams per liter (mg/L).
     + Optional	
@@ -142,7 +142,7 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `Cl-` : Concentration of chlorides.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: milligrams per liter (mg/L).
     + Optional	
@@ -150,12 +150,12 @@ Water Quality data model is intended to represent water quality parameters at a 
 + `NO3` : Concentration of nitrates.
     + Attribute type: [Number](http://schema.org/Number)
     + Attribute metadata:
-        + `dateUpdated`: Timestamp when the last update of the attribute happened.
+        + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Default unit: milligrams per liter (mg/L).
     + Optional		
 	 
-+ `dateUpdated` : Last update timestamp of this entity
++ `timestamp` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 

--- a/guidelines.md
+++ b/guidelines.md
@@ -75,7 +75,7 @@ the latter would be the creation date of the (digital) entity representing the w
 
 ## Dynamic attributes
 
-+ Use a metadata attribute named `dateUpdated` for capturing the last update timestamp of a dynamic attribute. Please note
++ Use a metadata attribute named `timestamp` for capturing the last update timestamp of a dynamic attribute. Please note
 that this is the actual date at which the measured value was obtained (from a sensor, by visual observation, etc.), and that
 date might be different than the date (metadata attribute named `dateModified` as per NGSIv2) at which the attribute
 of the digital entity was updated, as typically there might be delay,


### PR DESCRIPTION
please note that at entity level  `dateUpdated` is now `dateModified` as per NGSIv2 that's why a small number of renames are to `dateModified`