### PR TITLE
Use Travis CI and flake8 to ensure the code quality of future pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+cache: pip
+python:
+  - 2.7
+  - 3.6
+install:
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  E111,E114 allow two space indentation.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --ignore=E111,E114  --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  E111,E114 allow two space indentation.  The GitHub editor is 127 chars wide
+  # exit-zero treats all errors as warnings.  E111,E114 allow two space indentation.  GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --ignore=E111,E114  --max-complexity=10 --max-line-length=127 --statistics
 script:
   - true  # add other tests here


### PR DESCRIPTION
These tests currently pass so let's use Travis CI to ensure that future pull requests do not backslide.  The owner of the this repo would need to go to https://travis-ci.org/profile and flip the repository switch __on__ to enable free automated flake8 testing of each pull request.