### PR TITLE
Add owner to gsma common schema

### DIFF
--- a/Device/Device/doc/spec.md
+++ b/Device/Device/doc/spec.md
@@ -153,6 +153,10 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional    
 
++ `owner` : Entity's owners: an array of entities that represents the owners of an Thing.
+    + Attribute type: List of [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
+    + Optional
+
 ## Examples
 
     {
@@ -170,6 +174,7 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
       "value": "l=0.22;t=21.2",
       "deviceState": "ok",
       "dateFirstUsed": "2014-09-11",
+      "owner": ["http://person.org/leon"]
     }
 
 

--- a/Device/Device/doc/spec.md
+++ b/Device/Device/doc/spec.md
@@ -153,7 +153,7 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional    
 
-+ `owner` : Entity's owners: an array of entities that represents the owners of an Thing.
++ `owner` : Entity's owners: an array of entities that represents the owners of a Device.
     + Attribute type: List of [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
     + Optional
 

--- a/Device/Device/doc/spec.md
+++ b/Device/Device/doc/spec.md
@@ -153,8 +153,8 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional    
 
-+ `owner` : Entity's owners: an array of entities that represents the owners of a Device.
-    + Attribute type: List of [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
++ `owner` : The owners of a Device.
+    + Attribute type: List of references to [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
     + Optional
 
 ## Examples

--- a/common-schema.json
+++ b/common-schema.json
@@ -37,6 +37,12 @@
         },
         "dataProvider": {
           "type": "string"
+        },
+        "owner": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
         }
       }
     },

--- a/common-schema.json
+++ b/common-schema.json
@@ -41,15 +41,13 @@
         "owner": {
           "type": "array",
           "items": {
-            "type": "string",
             "oneOf": [ 
               {
+                "type": "string",
                 "format": "uri"
               },
               {
-                "minLength": 1,
-                "maxLength": 256,
-                "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$"
+                "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
               }
             ]
         }

--- a/common-schema.json
+++ b/common-schema.json
@@ -42,7 +42,16 @@
           "type": "array",
           "items": {
             "type": "string",
-            "format": "uri"
+            "oneOf": [ 
+              {
+                "format": "uri"
+              },
+              {
+                "minLength": 1,
+                "maxLength": 256,
+                "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$"
+              }
+            ]
         }
       }
     },

--- a/datamodel_template.md
+++ b/datamodel_template.md
@@ -20,6 +20,10 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional    
 
++ `owner` : Entity's owners: an array of entities that represents the owners of an Thing.
+    + Attribute type: List of [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
+    + Optional
+
 {{Location and address are two typical attributes that are added here for convenience}}
 
 + `location` : Location of {{entity type}} represented by a GeoJSON geometry. 

--- a/datamodel_template.md
+++ b/datamodel_template.md
@@ -20,8 +20,8 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional    
 
-+ `owner` : Entity's owners: an array of entities that represents the owners of an Thing.
-    + Attribute type: List of [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
++ `owner` : Entity's owners.
+    + Attribute type: List of references to [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
     + Optional
 
 {{Location and address are two typical attributes that are added here for convenience}}


### PR DESCRIPTION
Checking the original GSMA Device Data Model we found out that the owner attribute is missing. We believe this is an relevant attribute in several scenarios.
* Added owner property as array of uris to common-schema.json to match GSMA Device Data Model
* Added owner property to GSMA Device Data Model spec