### PR TITLE
Fix url string format PoinOfInteraction

### DIFF
--- a/PointOfInteraction/SmartPointOfInteraction/schema.json
+++ b/PointOfInteraction/SmartPointOfInteraction/schema.json
@@ -38,7 +38,7 @@
 			},
 			"applicationUrl": {
 				"type": "string",
-				"format": "url",
+				"format": "uri",
 				"description": "This field specifies the real URL containing the solution or application"
 			},
 			"availability": {

--- a/PointOfInteraction/SmartSpot/schema.json
+++ b/PointOfInteraction/SmartSpot/schema.json
@@ -17,7 +17,7 @@
 			},
 			"announcedUrl": {
 				"type": "string",
-				"format": "url",
+				"format": "uri",
 				"description": "URL broadcasted by the device"
 			},
 			"signalStrenght": {


### PR DESCRIPTION
afaik, url is not a valid format in json schema, replaced with uri
which is a super set of url, better would be probably to use a pattern.
feedbacks?