### PR TITLE
Remove anachronistic import with_statement

### DIFF
--- a/Environment/AirQualityObserved/harvest/barcelona_airquality_harvest.py
+++ b/Environment/AirQualityObserved/harvest/barcelona_airquality_harvest.py
@@ -174,8 +174,9 @@ def get_air_quality_barcelona(target_stations):
 
                         # Entity id corresponds to the observed date starting
                         # period (in local time)
-                        station_data['id'] = ('Barcelona-AirQualityObserved' +
-                            '-' + station_code + '-' + observ_date.isoformat())
+                        station_data['id'] = '-'.join('Barcelona-AirQualityObserved',
+                                                      station_code,
+                                                      observ_date.isoformat())
 
                         # Convenience data for filtering by target hour
                         station_data['hour'] = {
@@ -209,8 +210,9 @@ def get_air_quality_barcelona(target_stations):
         print(len(data_for_station))
         if len(data_for_station):
             last_measurement = data_for_station[-1]
-            last_measurement['id'] = ('Barcelona-AirQualityObserved' +
-                '-' + last_measurement['stationCode']['value'] + '-' + 'latest')
+            last_measurement['id'] = '-'.join('Barcelona-AirQualityObserved',
+                                              last_measurement['stationCode']['value'],
+                                              'latest')
 
         post_station_data(a_station, data_for_station)
 

--- a/Environment/AirQualityObserved/harvest/barcelona_airquality_harvest.py
+++ b/Environment/AirQualityObserved/harvest/barcelona_airquality_harvest.py
@@ -12,7 +12,6 @@
 
 '''
 
-from __future__ import with_statement
 from __future__ import print_function
 import datetime
 import json
@@ -22,8 +21,6 @@ import logging.handlers
 import re
 from pytz import timezone
 import contextlib
-
-import sys
 
 AIRQUALITY_TYPE_NAME = 'AirQualityObserved'
 
@@ -177,8 +174,8 @@ def get_air_quality_barcelona(target_stations):
 
                         # Entity id corresponds to the observed date starting
                         # period (in local time)
-                        station_data['id'] = 'Barcelona-AirQualityObserved' + \
-                            '-' + station_code + '-' + observ_date.isoformat()
+                        station_data['id'] = ('Barcelona-AirQualityObserved' +
+                            '-' + station_code + '-' + observ_date.isoformat())
 
                         # Convenience data for filtering by target hour
                         station_data['hour'] = {
@@ -212,8 +209,8 @@ def get_air_quality_barcelona(target_stations):
         print(len(data_for_station))
         if len(data_for_station):
             last_measurement = data_for_station[-1]
-            last_measurement['id'] = 'Barcelona-AirQualityObserved' + \
-                '-' + last_measurement['stationCode']['value'] + '-' + 'latest'
+            last_measurement['id'] = ('Barcelona-AirQualityObserved' +
+                '-' + last_measurement['stationCode']['value'] + '-' + 'latest')
 
         post_station_data(a_station, data_for_station)
 
@@ -293,10 +290,10 @@ def post_station_data(station_code, data):
         len(data))
 
     try:
-        with contextlib.closing(urllib2.urlopen(req)) as f:
+        with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
             global persisted_entities
             logger.debug("Entity successfully created: %s", station_code)
-            persisted_entities = persisted_entities + 1
+            persisted_entities += 1
     except urllib2.URLError as e:
         global in_error_entities
         logger.error(
@@ -304,7 +301,7 @@ def post_station_data(station_code, data):
             e.code,
             e.read())
         logger.debug('Data which failed: %s', data_as_str)
-        in_error_entities = in_error_entities + 1
+        in_error_entities += 1
 
 
 def setup_logger():

--- a/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
+++ b/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
@@ -207,8 +207,9 @@ def get_air_quality_madrid():
                 # Last measurement is duplicated to have an entity with the
                 # latest measurement obtained
                 last_measurement = data_array[-1]
-                last_measurement['id'] = ('Madrid-AirQualityObserved-' +
-                    last_measurement['stationCode']['value'] + '-' + 'latest')
+                last_measurement['id'] = '-'.join('Madrid', 'AirQualityObserved',
+                                                  last_measurement['stationCode']['value'],
+                                                  'latest')
             else:
                 logger.warn('No data retrieved for: %s', station)
 
@@ -253,8 +254,8 @@ def build_station(station_num, station_code, hour, row):
     }
 
     valid_from = datetime.datetime(int(row[6]), int(row[7]), int(row[8]), hour)
-    station_data['id'] = ('Madrid-AirQualityObserved-' +
-        station_code + '-' + valid_from.isoformat())
+    station_data['id'] = '-'.join('Madrid', 'AirQualityObserved',
+                                  station_code, valid_from.isoformat())
     valid_to = (valid_from + datetime.timedelta(hours=1))
 
     # Adjust timezones

--- a/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
+++ b/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
@@ -1,7 +1,6 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 import csv
 import datetime
@@ -13,7 +12,6 @@ import logging.handlers
 import re
 from pytz import timezone
 import contextlib
-import copy
 
 
 try:
@@ -209,8 +207,8 @@ def get_air_quality_madrid():
                 # Last measurement is duplicated to have an entity with the
                 # latest measurement obtained
                 last_measurement = data_array[-1]
-                last_measurement['id'] = 'Madrid-AirQualityObserved-' + \
-                    last_measurement['stationCode']['value'] + '-' + 'latest'
+                last_measurement['id'] = ('Madrid-AirQualityObserved-' +
+                    last_measurement['stationCode']['value'] + '-' + 'latest')
             else:
                 logger.warn('No data retrieved for: %s', station)
 
@@ -255,8 +253,8 @@ def build_station(station_num, station_code, hour, row):
     }
 
     valid_from = datetime.datetime(int(row[6]), int(row[7]), int(row[8]), hour)
-    station_data['id'] = 'Madrid-AirQualityObserved-' + \
-        station_code + '-' + valid_from.isoformat()
+    station_data['id'] = ('Madrid-AirQualityObserved-' +
+        station_code + '-' + valid_from.isoformat())
     valid_to = (valid_from + datetime.timedelta(hours=1))
 
     # Adjust timezones
@@ -317,7 +315,7 @@ def post_station_data(station_code, data):
         len(data))
 
     try:
-        with contextlib.closing(urllib2.urlopen(req)) as f:
+        with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
             global persisted_entities
             logger.debug("Entity successfully created: %s", station_code)
             persisted_entities = persisted_entities + 1

--- a/Environment/AirQualityObserved/harvest/malaga_airqualityobserved_import.py
+++ b/Environment/AirQualityObserved/harvest/malaga_airqualityobserved_import.py
@@ -1,16 +1,11 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import csv
-import datetime
 import json
 import urllib2
-import StringIO
 import logging
 import logging.handlers
-import re
-from pytz import timezone
 import contextlib
 
 pollutant_descriptions = {
@@ -87,8 +82,8 @@ def process_csv_row(row, pollutant, unit_code):
     if zone not in area_data:
         return
 
-    geometry = area_data[zone]['geometry']
-    place_name = area_data[zone]['name']
+    # geometry = area_data[zone]['geometry']
+    # place_name = area_data[zone]['name']
 
     key = zone + '-' + zone_type + '-' + date
     if key not in airquality_data:
@@ -101,8 +96,8 @@ def process_csv_row(row, pollutant, unit_code):
         return
 
     # Now adding the pollutant data
-    pollutant_data = pollutant + ', ' + \
-        str(float(value)) + ', ' + unit_code + ', ' + pollutant_descriptions[pollutant]
+    pollutant_data = ','.join(pollutant, str(float(value)), unit_code,
+                              pollutant_descriptions[pollutant])
     entity['measurand']['value'].append(pollutant_data)
     entity[pollutant] = {
         'value': float(value)
@@ -220,7 +215,7 @@ def post_data(data):
         headers=headers)
 
     try:
-        with contextlib.closing(urllib2.urlopen(req)) as f:
+        with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
             global persisted_entities
             logger.debug(
                 "Entity batch successfully created: %s",

--- a/Environment/AirQualityObserved/harvest/santander_federation.py
+++ b/Environment/AirQualityObserved/harvest/santander_federation.py
@@ -3,10 +3,9 @@
 # The notification messages are listened and data is sent to FIWARE GSMA
 # instance
 
-from __future__ import with_statement
 from __future__ import print_function
 import json
-from flask import Flask, jsonify, request, Response
+from flask import Flask, request
 import urllib2
 import contextlib
 import logging
@@ -49,7 +48,7 @@ def post_data(data):
         headers=headers)
 
     try:
-        with contextlib.closing(urllib2.urlopen(req)) as f:
+        with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
             app.logger.debug("Entity batch successfully created!")
     except urllib2.URLError as e:
         app.logger.error(

--- a/PointOfInterest/import_pois_tourspain.py
+++ b/PointOfInterest/import_pois_tourspain.py
@@ -1,7 +1,6 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 import sys
 import os
@@ -176,7 +175,8 @@ def get_description(DOMTree, index_poi_type):
 
             content_nodes = node.getElementsByTagName('content')
             for content_node in content_nodes:
-                if content_node.firstChild is not None and content_node.firstChild.nodeValue is not None:
+                if (content_node.firstChild is not None and
+                        content_node.firstChild.nodeValue is not None):
                     text = content_node.firstChild.nodeValue
                     text_filtered = text.strip()
 
@@ -190,8 +190,8 @@ def get_description(DOMTree, index_poi_type):
 
                     description = sanitize(text_filtered)
                     # There are more spureous tags in the description
-                    # TODO: Remove any markup in the description by using an appropriate
-                    # regular expression
+                    # TODO: Remove any markup in the description by using an
+                    # appropriate regular expression
                     description.replace(
                         '<strong>', '').replace(
                         '</strong>', '')
@@ -238,12 +238,12 @@ def post_data(data):
         headers=headers)
 
     try:
-        with contextlib.closing(urllib2.urlopen(req)) as f:
+        with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
             global persisted_entities
-            persisted_entities = persisted_entities + 1
+            persisted_entities += 1
     except urllib2.URLError as e:
         global in_error_entities
-        in_error_entities = in_error_entities + 1
+        in_error_entities += 1
 
 
 if __name__ == '__main__':

--- a/Transportation/Bike/BikeHireDockingStation/harvest/bicycle_hire_station_barcelona_harvest.py
+++ b/Transportation/Bike/BikeHireDockingStation/harvest/bicycle_hire_station_barcelona_harvest.py
@@ -6,7 +6,6 @@ Harmonises data from the city of Barcelona corresponding to
 the bicycle hiring stations
 """
 
-from __future__ import with_statement
 from __future__ import print_function
 import contextlib
 import json
@@ -141,7 +140,7 @@ def persist_data(entity_list):
         headers=headers)
 
     try:
-        with contextlib.closing(urlopen(req)) as f:
+        with contextlib.closing(urlopen(req)) as f:  # noqa F841
             print('Entities successfully created')
     except URLError as e:
         print('Error while POSTing data to Orion: %d %s' % (e.code, e.read()))
@@ -155,17 +154,8 @@ def main():
         print("Source data could not be read")
         exit()
 
-    parsed_data = json.loads(data)
-
-    station_list = parsed_data['stations']
-
-    ngsi_data = []
-
-    for station in station_list:
-        h_station = harmonize_station(station)
-        ngsi_data.append(h_station)
-
-    persist_data(ngsi_data)
+    persist_data([harmonize_station(station) for station
+                  in json.loads(data)['stations']])
 
 
 if __name__ == '__main__':

--- a/Weather/WeatherForecast/harvest/portugal_weather_forecast_harvest.py
+++ b/Weather/WeatherForecast/harvest/portugal_weather_forecast_harvest.py
@@ -3,12 +3,10 @@
 Gets weather forecast from the portuguese meteorological service, ipma.pt
 """
 
-from __future__ import with_statement
 import urllib2
 import json
 from dateutil import parser
 import datetime
-import sys
 from pytz import timezone
 import logging
 import logging.handlers
@@ -71,14 +69,8 @@ ipma_url = 'https://api.ipma.pt/json/alldata/{}.json'
 
 
 def get_weather_forecasted():
-    data = {}
-
-    for locality in iptma_codes:
-        code = iptma_codes[locality]
-
-        data[code] = get_weather_forecasted_pt(locality)
-
-    return data
+    return {iptma_codes[locality]: get_weather_forecasted_pt(locality)
+            for locality in iptma_codes}
 
 
 def get_weather_forecasted_pt(locality):
@@ -202,8 +194,9 @@ def get_weather_forecasted_pt(locality):
                 'value': weather_type_dict[weather_type_id]
             }
 
-        obj['id'] = 'Portugal' + '-' + 'WeatherForecast' + '-' + locality + \
-            '_' + obj['validFrom']['value'] + '_' + obj['validTo']['value']
+        obj['id'] = '-'.join('Portugal', 'WeatherForecast', locality,
+                             obj['validFrom']['value'],
+                             obj['validTo']['value'])
         obj['source'] = {
             'type': 'URL',
             'value': 'https://www.ipma.pt'
@@ -216,10 +209,7 @@ def get_weather_forecasted_pt(locality):
 
 def get_data(forecast, item):
     value = float(forecast[item])
-    if value == -99.0:
-        value = None
-
-    return value
+    return None if value == -99.0 else value
 
 
 def post_data(data):
@@ -252,10 +242,9 @@ def post_data(data):
             headers=headers)
 
         try:
-            with contextlib.closing(urllib2.urlopen(req)) as f:
+            with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
                 global persisted_entities
-                persisted_entities = persisted_entities + \
-                    len(data[a_postal_code])
+                persisted_entities += len(data[a_postal_code])
                 logger.debug(
                     'Entities successfully created for postal code: %s',
                     a_postal_code)
@@ -267,7 +256,7 @@ def post_data(data):
                 e.code,
                 e.read())
             logger.debug('Data which failed: %s', data_as_str)
-            in_error_entities = in_error_entities + 1
+            in_error_entities += 1
 
 
 def setup_logger():

--- a/Weather/WeatherForecast/harvest/spain_weather_forecast_harvest.py
+++ b/Weather/WeatherForecast/harvest/spain_weather_forecast_harvest.py
@@ -1,16 +1,12 @@
 #!bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import urllib2
 import xml.dom.minidom
 import datetime
 import json
 import copy
 from dateutil import parser
-import csv
-import StringIO
-import re
 from pytz import timezone
 import logging
 import logging.handlers
@@ -72,7 +68,7 @@ aemet_service = "http://www.aemet.es/xml/municipios/localidad_{}.xml"
 
 
 def decode_wind_direction(direction):
-    dictionary = {
+    return {
         'Norte': 180,
         'Sur': 0,
         'Este': -90,
@@ -89,12 +85,7 @@ def decode_wind_direction(direction):
         'NO': 45,
         'SE': -135,
         'SO': 135
-    }
-
-    if direction in dictionary:
-        return dictionary[direction]
-    else:
-        return None
+    }.get(direction, None)
 
 ######
 
@@ -138,7 +129,7 @@ def decode_weather_type(weather_type):
         trailing = ', night'
         param = param[0:param.index('noche')].strip()
 
-    dictionary = {
+    out = {
         'despejado': 'sunnyDay',
         'poco nuboso': 'slightlyCloudy',
         'intervalos nubosos': 'partlyCloudy',
@@ -170,16 +161,8 @@ def decode_weather_type(weather_type):
         'nuboso con tormenta y lluvia escasa': 'cloudy, thunder, lightRainShower',
         'muy nuboso con tormenta y lluvia escasa': 'veryCloudy, thunder, lightRainShower',
         'cubierto con tormenta y lluvia escasa': 'overcast, thunder, lightRainShower',
-        'despejado noche': 'clearNight'}
-
-    if param in dictionary:
-        out = dictionary[param] + trailing
-    else:
-        out = None
-
-    return out
-
-#########
+        'despejado noche': 'clearNight'}.get(param, None)
+    return out + trailing if out else None
 
 
 def get_weather_forecasted():
@@ -385,10 +368,7 @@ def get_parameter_data(node, periods, parameter, factor=1.0):
         hour_str = param.getAttribute('hora')
         hour = int(hour_str)
         interval_start = hour - 6
-        interval_start_str = str(interval_start)
-        if interval_start < 10:
-            interval_start_str = '0' + str(interval_start)
-
+        interval_start_str = '{:02}'.format(interval_start)
         period = interval_start_str + '-' + hour_str
         if param.firstChild and param.firstChild.nodeValue:
             param_val = float(param.firstChild.nodeValue)
@@ -443,10 +423,9 @@ def post_data(data):
             headers=headers)
 
         try:
-            with contextlib.closing(urllib2.urlopen(req)) as f:
+            with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
                 global persisted_entities
-                persisted_entities = persisted_entities + \
-                    len(data[a_postal_code])
+                persisted_entities += len(data[a_postal_code])
                 logger.debug(
                     'Entities successfully created for postal code: %s',
                     a_postal_code)
@@ -458,7 +437,7 @@ def post_data(data):
                 e.code,
                 e.read())
             logger.debug('Data which failed: %s', data_as_str)
-            in_error_entities = in_error_entities + 1
+            in_error_entities += 1
 
 
 def setup_logger():

--- a/Weather/WeatherObserved/harvest/portugal_weather_observed_harvest.py
+++ b/Weather/WeatherObserved/harvest/portugal_weather_observed_harvest.py
@@ -122,8 +122,8 @@ def get_weather_observed_portugal():
     for station_code in observation_data:
         if len(observation_data[station_code]) > 0:
             latest_observation = observation_data[station_code][-1]
-            latest_observation['id'] = ('Portugal-WeatherObserved' +
-                '-' + station_code + '-' + 'latest')
+            latest_observation['id'] = '-'.join('Portugal', 'WeatherObserved',
+                                                station_code, 'latest')
 
         post_station_data_batch(station_code, observation_data[station_code])
 

--- a/Weather/WeatherObserved/harvest/portugal_weather_observed_harvest.py
+++ b/Weather/WeatherObserved/harvest/portugal_weather_observed_harvest.py
@@ -1,15 +1,10 @@
 #!bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import urllib2
-import StringIO
-import csv
-import datetime
 import json
 import logging
 import logging.handlers
-from pytz import timezone
 import contextlib
 import re
 
@@ -127,8 +122,8 @@ def get_weather_observed_portugal():
     for station_code in observation_data:
         if len(observation_data[station_code]) > 0:
             latest_observation = observation_data[station_code][-1]
-            latest_observation['id'] = 'Portugal-WeatherObserved' + \
-                '-' + station_code + '-' + 'latest'
+            latest_observation['id'] = ('Portugal-WeatherObserved' +
+                '-' + station_code + '-' + 'latest')
 
         post_station_data_batch(station_code, observation_data[station_code])
 
@@ -170,7 +165,7 @@ def post_station_data_batch(station_code, data):
         headers=headers)
 
     try:
-        with contextlib.closing(urllib2.urlopen(req)) as f:
+        with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
             global persisted_entities
             global persisted_stations
             persisted_entities = persisted_entities + len(data)

--- a/Weather/WeatherObserved/harvest/spain_weather_observed_harvest.py
+++ b/Weather/WeatherObserved/harvest/spain_weather_observed_harvest.py
@@ -202,8 +202,8 @@ def get_weather_observed_spain():
                 'type': 'PostalAddress'}
             observation['location'] = station_data[station_code]['location']
 
-            observation['id'] = ('Spain-WeatherObserved' + '-' +
-                station_code + '-' + date_observed.isoformat())
+            observation['id'] = '-'.join('Spain', 'WeatherObserved',
+                                         station_code, date_observed.isoformat())
 
             out.append(observation)
 
@@ -212,8 +212,8 @@ def get_weather_observed_spain():
         # Last observation is tagged as 'latest'
         if len(out) > 0:
             latest_observation = out[-1]
-            latest_observation['id'] = ('Spain-WeatherObserved' +
-                '-' + station_code + '-' + 'latest')
+            latest_observation['id'] = '-'.join('Spain', 'WeatherObserved',
+                                                station_code, 'latest')
 
         # A batch of station data is persisted
         post_station_data_batch(station_code, out)

--- a/Weather/WeatherObserved/harvest/spain_weather_observed_harvest.py
+++ b/Weather/WeatherObserved/harvest/spain_weather_observed_harvest.py
@@ -1,7 +1,6 @@
 #!bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import urllib2
 import StringIO
 import csv
@@ -109,7 +108,7 @@ def sanitize(str_in):
 
 def get_data(row, index, conversion=float, factor=1.0):
     value = row[index]
-    return None if value == '' else conversion(value) / factor 
+    return None if value == '' else conversion(value) / factor
 
 
 def get_weather_observed_spain():
@@ -203,8 +202,8 @@ def get_weather_observed_spain():
                 'type': 'PostalAddress'}
             observation['location'] = station_data[station_code]['location']
 
-            observation['id'] = 'Spain-WeatherObserved' + '-' + \
-                station_code + '-' + date_observed.isoformat()
+            observation['id'] = ('Spain-WeatherObserved' + '-' +
+                station_code + '-' + date_observed.isoformat())
 
             out.append(observation)
 
@@ -213,8 +212,8 @@ def get_weather_observed_spain():
         # Last observation is tagged as 'latest'
         if len(out) > 0:
             latest_observation = out[-1]
-            latest_observation['id'] = 'Spain-WeatherObserved' + \
-                '-' + station_code + '-' + 'latest'
+            latest_observation['id'] = ('Spain-WeatherObserved' +
+                '-' + station_code + '-' + 'latest')
 
         # A batch of station data is persisted
         post_station_data_batch(station_code, out)
@@ -249,7 +248,7 @@ def post_station_data_batch(station_code, data):
         headers=headers)
 
     try:
-        with contextlib.closing(urllib2.urlopen(req)) as f:
+        with contextlib.closing(urllib2.urlopen(req)) as f:  # noqa F841
             global persisted_entities
             global persisted_stations
             persisted_entities = persisted_entities + len(data)


### PR DESCRIPTION
Fixes #169  Remove `from __future__ import with_statement` which has not been needed post Python 2.5.  Also, clean up flake8 issues in each file...
* Remove unused imports
* Remove or mark with _noqa_ unused variables
* Remove backslash line termination with parens or str.join()
* Use += instead of repeating variable name
* list comprehension, dict comprehension, dict.get(), str.format(), ternary if
