### PR TITLE
Remove anachronistic import with_statement (not so scary version)

### DIFF
--- a/Environment/AirQualityObserved/harvest/barcelona_airquality_harvest.py
+++ b/Environment/AirQualityObserved/harvest/barcelona_airquality_harvest.py
@@ -12,7 +12,6 @@
 
 '''
 
-from __future__ import with_statement
 from __future__ import print_function
 import datetime
 import json

--- a/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
+++ b/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
@@ -1,7 +1,6 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 import csv
 import datetime

--- a/Environment/AirQualityObserved/harvest/malaga_airqualityobserved_import.py
+++ b/Environment/AirQualityObserved/harvest/malaga_airqualityobserved_import.py
@@ -1,7 +1,6 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import csv
 import datetime
 import json

--- a/Environment/AirQualityObserved/harvest/santander_federation.py
+++ b/Environment/AirQualityObserved/harvest/santander_federation.py
@@ -3,7 +3,6 @@
 # The notification messages are listened and data is sent to FIWARE GSMA
 # instance
 
-from __future__ import with_statement
 from __future__ import print_function
 import json
 from flask import Flask, jsonify, request, Response

--- a/PointOfInterest/import_pois_tourspain.py
+++ b/PointOfInterest/import_pois_tourspain.py
@@ -1,7 +1,6 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 import sys
 import os

--- a/Transportation/Bike/BikeHireDockingStation/harvest/bicycle_hire_station_barcelona_harvest.py
+++ b/Transportation/Bike/BikeHireDockingStation/harvest/bicycle_hire_station_barcelona_harvest.py
@@ -6,7 +6,6 @@ Harmonises data from the city of Barcelona corresponding to
 the bicycle hiring stations
 """
 
-from __future__ import with_statement
 from __future__ import print_function
 import contextlib
 import json

--- a/Weather/WeatherForecast/harvest/portugal_weather_forecast_harvest.py
+++ b/Weather/WeatherForecast/harvest/portugal_weather_forecast_harvest.py
@@ -3,7 +3,6 @@
 Gets weather forecast from the portuguese meteorological service, ipma.pt
 """
 
-from __future__ import with_statement
 import urllib2
 import json
 from dateutil import parser

--- a/Weather/WeatherForecast/harvest/spain_weather_forecast_harvest.py
+++ b/Weather/WeatherForecast/harvest/spain_weather_forecast_harvest.py
@@ -1,7 +1,6 @@
 #!bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import urllib2
 import xml.dom.minidom
 import datetime

--- a/Weather/WeatherObserved/harvest/portugal_weather_observed_harvest.py
+++ b/Weather/WeatherObserved/harvest/portugal_weather_observed_harvest.py
@@ -1,7 +1,6 @@
 #!bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import urllib2
 import StringIO
 import csv

--- a/Weather/WeatherObserved/harvest/spain_weather_observed_harvest.py
+++ b/Weather/WeatherObserved/harvest/spain_weather_observed_harvest.py
@@ -1,7 +1,6 @@
 #!bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 import urllib2
 import StringIO
 import csv
@@ -109,7 +108,7 @@ def sanitize(str_in):
 
 def get_data(row, index, conversion=float, factor=1.0):
     value = row[index]
-    return None if value == '' else conversion(value) / factor 
+    return None if value == '' else conversion(value) / factor
 
 
 def get_weather_observed_spain():


### PR DESCRIPTION
Fixes #169 Remove `from __future__ import with_statement` which has not been needed post Python 2.5.