### PR TITLE
minor fixes to Device and DeviceModel documentation

### DIFF
--- a/Device/Device/doc/spec.md
+++ b/Device/Device/doc/spec.md
@@ -132,7 +132,7 @@ and which are not currently covered by the standard attributes defined by this m
     + Optional
 
 + `dateLastValueReported` : A timestamp which denotes the last time when the device successfully reported data to the cloud.
-    + Attribute type: [DateTime](https://schema.org/)
+    + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 
 + `value` : A observed or reported value. For actuator devices, it is an attribute that allows
@@ -154,7 +154,7 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
     + Optional    
 
 + `owner` : The owners of a Device.
-    + Attribute type: List of references to [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).
+    + Attribute type: List of references to [Person](http://schema.org/Person) or [Organization](https://schema.org/Organization).
     + Optional
 
 ## Examples
@@ -169,11 +169,11 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
       "mcc": "214",
       "mnc": "07",
       "batteryLevel": 0.75,
-      "serialNumer": "9845A",
+      "serialNumber": "9845A",
       "refDeviceModel": "myDevice-wastecontainer-sensor-345",
       "value": "l=0.22;t=21.2",
       "deviceState": "ok",
-      "dateFirstUsed": "2014-09-11",
+      "dateFirstUsed": "2014-09-11T11:00:00Z",
       "owner": ["http://person.org/leon"]
     }
 

--- a/Device/DeviceModel/doc/spec.md
+++ b/Device/DeviceModel/doc/spec.md
@@ -38,7 +38,7 @@ If the device is not a constrained device this property can be left as `null` or
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed values: (some of this values are defined as instances of the class `Property` in SAREF)
         + (`temperature`, `humidity`, `light`, `motion`, `fillingLevel`, `occupancy`, `power`, `pressure`, `smoke`, `energy`, `airPollution`, `noiseLevel`,
-        `weatherConditions`, `precipitation`, `windSpeed`, `windDirection`, `barometricPressure`, `solarRadiation`, `depth`, `pH`, `pressure`, `conductivity`,
+        `weatherConditions`, `precipitation`, `windSpeed`, `windDirection`, `barometricPressure`, `solarRadiation`, `depth`, `pH`, `conductivity`,
         `conductance`, `tss`, `tds`, `turbidity`, `salinity`, `orp`, `cdom`, `waterPollution`, `location`, `speed`, `heading`, `weight`, `waterConsumption`,
         `gasComsumption`, `electricityConsumption`)
     + Mandatory


### PR DESCRIPTION
* Missing `DateTime` in Device spec
* Misspelling in the Device example
* Incorrect date format in the Device example (it was Date while the
specs reports DateTime)
* Removed duplicated `pressure`in DeviceModel