### PR TITLE
BikeHireDockingStation: add empty and almostEmpty status

### DIFF
--- a/Transportation/Bike/BikeHireDockingStation/doc/spec.md
+++ b/Transportation/Bike/BikeHireDockingStation/doc/spec.md
@@ -98,7 +98,7 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
         +   `timestamp` : Timestamp of the last attribute update.
         +   Type: [DateTime](https://schema.org/DateTime)
     +   Allowed values:
-        +   (`working`, `outOfService`, `withIncidence`, `full`, `almostFull`)
+        +   (`working`, `outOfService`, `withIncidence`, `full`, `almostFull`, `empty`, `almostEmpty`)
         +   Or any other application+specific.
     +   Optional
 

--- a/Transportation/Bike/BikeHireDockingStation/schema.json
+++ b/Transportation/Bike/BikeHireDockingStation/schema.json
@@ -45,7 +45,9 @@
 						"outOfService",
 						"withIncidence",
 						"full",
-						"almostFull"
+						"almostFull",
+						"empty",
+						"almostEmpty"
 					]
 				},
 				"minItems": 1,


### PR DESCRIPTION
`BikeHireDockingStation` Spec allows to use the `full` and `almostFull` statuses, but not the opposites: `empty` and `almostEmpty`. From the point of view of a docking station manager, those status are useful as they indicates that some maintenance task has to be done (e.g. moving some bikes to the empty docking stations so clients can use them). We know that the spec does not forbid the use of those status, but we think they will be used with the same frequency as `full` and `almostFull`, so it is better to have them documented.