### PR TITLE
Use Atmospheric Pressure instead of Barometric Pressure

### DIFF
--- a/Device/DeviceModel/doc/spec.md
+++ b/Device/DeviceModel/doc/spec.md
@@ -38,11 +38,11 @@ If the device is not a constrained device this property can be left as `null` or
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed values: (some of this values are defined as instances of the class `Property` in SAREF)
         + (`temperature`, `humidity`, `light`, `motion`, `fillingLevel`, `occupancy`, `power`, `pressure`, `smoke`, `energy`, `airPollution`, `noiseLevel`,
-        `weatherConditions`, `precipitation`, `windSpeed`, `windDirection`, `barometricPressure`, `solarRadiation`, `depth`, `pH`, `conductivity`,
+        `weatherConditions`, `precipitation`, `windSpeed`, `windDirection`, `atmosphericPressure`, `solarRadiation`, `depth`, `pH`, `conductivity`,
         `conductance`, `tss`, `tds`, `turbidity`, `salinity`, `orp`, `cdom`, `waterPollution`, `location`, `speed`, `heading`, `weight`, `waterConsumption`,
         `gasComsumption`, `electricityConsumption`, `soilMoisture`, `trafficFlow`)
     + Mandatory
-        
+
 + `function` :  The functionality necessary to accomplish the task for which a Device is designed. A device can be designed to perform more than one function.
     Defined by [SAREF](https://w3id.org/saref#Function).
     + Attribute type: List of [Text](https://schema.org/Text)

--- a/Device/DeviceModel/schema.json
+++ b/Device/DeviceModel/schema.json
@@ -52,7 +52,7 @@
               "precipitation",
               "windSpeed",
               "windDirection",
-              "barometricPressure",
+              "atmosphericPressure",
               "solarRadiation",
               "depth",
               "pH",

--- a/Device/device-schema.json
+++ b/Device/device-schema.json
@@ -43,7 +43,7 @@
           "precipitation",
           "windSpeed",
           "windDirection",
-          "barometricPressure",
+          "atmosphericPressure",
           "solarRadiation",
           "depth",
           "pH",

--- a/Environment/AirQualityObserved/harvest/madrid_air_quality.py
+++ b/Environment/AirQualityObserved/harvest/madrid_air_quality.py
@@ -68,7 +68,7 @@ other_dict = {
     '82': 'windDirection',
     '83': 'temperature',
     '86': 'relativeHumidity',
-    '87': 'barometricPressure',
+    '87': 'atmosphericPressure',
     '88': 'solarRadiation',
     '89': 'precipitation',
     '92': 'acidRainLevel'
@@ -80,7 +80,7 @@ other_descriptions = {
     '82': 'Wind Direction',
     '83': 'temperature',
     '86': 'Relative Humidity',
-    '87': 'Barometric Pressure',
+    '87': 'Atmospheric Pressure',
     '88': 'Solar Radiation',
     '89': 'Precipitation',
     '92': 'Acid Rain Level'

--- a/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
+++ b/Environment/AirQualityObserved/harvest/madrid_air_quality_harvest.py
@@ -79,7 +79,7 @@ other_dict = {
     '82': 'windDirection',
     '83': 'temperature',
     '86': 'relativeHumidity',
-    '87': 'barometricPressure',
+    '87': 'atmosphericPressure',
     '88': 'solarRadiation',
     '89': 'precipitation',
     '92': 'acidRainLevel'
@@ -91,7 +91,7 @@ other_descriptions = {
     '82': 'Wind Direction',
     '83': 'temperature',
     '86': 'Relative Humidity',
-    '87': 'Barometric Pressure',
+    '87': 'Atmospheric Pressure',
     '88': 'Solar Radiation',
     '89': 'Precipitation',
     '92': 'Acid Rain Level'

--- a/Weather/WeatherObserved/doc/spec.md
+++ b/Weather/WeatherObserved/doc/spec.md
@@ -108,15 +108,15 @@ mapping for Spanish terms can be found [here](https://github.com/Fiware/dataMode
         + `timestamp` : optional timestamp for the observed value. It can be ommitted if the observation time is the same as the one captured
         by the `dateObserved` attribute at entity level.
     + Optional
-    
-+ `barometricPressure` : The barometric pressure observed measured in Hecto Pascals.
+
++ `atmosphericPressure` : The atmospheric pressure observed measured in Hecto Pascals.
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: Hecto Pascals
     + Attribute metadata:
         + `timestamp` : optional timestamp for the observed value. It can be ommitted if the observation time is the same as the one captured
         by the `dateObserved` attribute at entity level.
     + Optional
-    
+
 + `pressureTendency` : Is the pressure rising or falling? It can be expressed in quantitative terms or qualitative terms. 
     + Attribute type: [Text](https://schema.org/Text) or [Number](https://schema.org/Number)
     + Allowed values, if expressed in quantitative terms: one Of (`raising`, `falling`, `steady`)
@@ -153,7 +153,7 @@ mode (`options=keyValues`).
                 "addressLocality": "Valladolid",
                 "addressCountry": "ES"
             },
-            "barometricPressure": 938.9,
+            "atmosphericPressure": 938.9,
             "dataProvider": "TEF",
             "dateObserved": "2016-11-30T07:00:00.00Z",
             "location":

--- a/Weather/WeatherObserved/example.json
+++ b/Weather/WeatherObserved/example.json
@@ -6,7 +6,7 @@
                 "addressLocality": "Valladolid",
                 "addressCountry": "ES"
             },
-            "barometricPressure": 938.9,
+            "atmosphericPressure": 938.9,
             "dataProvider": "TEF",
             "dateObserved": "2016-11-30T07:00:00.00Z",
             "location":

--- a/Weather/WeatherObserved/schema.json
+++ b/Weather/WeatherObserved/schema.json
@@ -25,7 +25,7 @@
           "type": "number",
           "minimum": 0
         },
-        "barometricPressure": {
+        "atmosphericPressure": {
           "type": "number",
           "minimum": 0
         },


### PR DESCRIPTION
This PR fixes issue #234, that is, it replaces the `barometricPressure` attribute on the `WeatherObserved` model with the `atmosphericPressure` attribute, that is the attribute documented by GSMA. This PR also replaces other occurrences in the `DeviceModel` spec and in the `AirQualityObserved` example harvesters.