### PR TITLE
ADD read-only automatically generated to dateCreated and dateModified attributes/metadata

### DIFF
--- a/Building/Building/doc/spec.md
+++ b/Building/Building/doc/spec.md
@@ -31,11 +31,13 @@ For a full description of the following attributes refer to GSMA
 
 + `type`
 
-+ `dateModified`
-    + Optional
++ `dateModified` : Last update timestamp of this entity.
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Read-Only. Automatically generated.
 
-+ `dateCreated`
-    + Optional
++ `dateCreated` : Entity's creation timestamp.
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Read-Only. Automatically generated.
 
 + `owner`
     + Optional

--- a/Building/BuildingOperation/doc/spec.md
+++ b/Building/BuildingOperation/doc/spec.md
@@ -23,11 +23,13 @@ For a full description of the following attributes refer to GSMA
 
 + `type`` : Entity type. It must be equal to `BuildingOperation`.`
 
-+ `dateModified`
-    + Optional
++ `dateModified` : Last update timestamp of this entity.
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Read-Only. Automatically generated.
 
-+ `dateCreated`
-    + Optional    
++ `dateCreated` : Entity's creation timestamp.
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Read-Only. Automatically generated.
 
 + `description`
     + Optional

--- a/Device/Device/doc/spec.md
+++ b/Device/Device/doc/spec.md
@@ -52,8 +52,9 @@ parameters which have to do with the configuration of a device (timeouts, report
 and which are not currently covered by the standard attributes defined by this model. 
     + Attribute type: [StructuredValue](https://schema.org/StructuredValue)
     + Attribute metadata:
-        + `dateModified` :  It captures the last modification timestamp of this attribute.
-            + Type: [DateTime](https://schema.org/DateTime) 
+        + `dateModified` :  Last update timestamp of this attribute.
+            + Metadata type: [DateTime](https://schema.org/DateTime)
+			+ Read-Only. Automatically generated.
     + Optional
     
 + `location` : Location of this device represented by a GeoJSON geometry of type point. 
@@ -147,11 +148,11 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
     
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `owner` : The owners of a Device.
     + Attribute type: List of references to [Person](http://schema.org/Person) or [Organization](https://schema.org/Organization).

--- a/Device/DeviceModel/doc/spec.md
+++ b/Device/DeviceModel/doc/spec.md
@@ -100,11 +100,11 @@ If the device is not a constrained device this property can be left as `null` or
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`

--- a/Environment/AeroAllergenObserved/doc/spec.md
+++ b/Environment/AeroAllergenObserved/doc/spec.md
@@ -23,11 +23,11 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `location` : Location of the aero allergens observation represented by a GeoJSON geometry. 
     + Attribute type: `geo:json`.

--- a/Environment/AirQualityObserved/doc/spec.md
+++ b/Environment/AirQualityObserved/doc/spec.md
@@ -15,11 +15,11 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `location` : Location of the air quality observation represented by a GeoJSON geometry. 
     + Attribute type: `geo:json`.

--- a/Environment/AirQualityObserved/harvest/madrid_air_quality.py
+++ b/Environment/AirQualityObserved/harvest/madrid_air_quality.py
@@ -219,8 +219,9 @@ def get_air_quality_madrid(target_stations, target_hour=-1):
                         'streetAddress': station_dict[station_num]['address']
                     },
                     'location': station_dict[station_num]['location'] or None,
-                    'source': 'http://datos.madrid.es',
-                    'dateCreated': datetime.datetime.now().isoformat()
+                    'source': 'http://datos.madrid.es'
+                    # According to read-only nature of dateCreated, it must not be added
+                    #'dateCreated': datetime.datetime.now().isoformat()
                 }
                 valid_from = datetime.datetime(
                     int(row[6]), int(row[7]), int(row[8]), hour)

--- a/Environment/NoiseLevelObserved/doc/spec.md
+++ b/Environment/NoiseLevelObserved/doc/spec.md
@@ -13,11 +13,11 @@ This entity is primarily associated with the Smart City and environment vertical
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `location` : Location of this observation represented by a GeoJSON geometry. 
     + Attribute type: `geo:json`.

--- a/Environment/WaterQualityObserved/doc/spec.md
+++ b/Environment/WaterQualityObserved/doc/spec.md
@@ -14,11 +14,11 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `location` : Location where measurements have been taken, represented by a GeoJSON Point. 
     + Attribute type: `geo:json`.

--- a/IssueTracking/Open311_ServiceType/doc/spec.md
+++ b/IssueTracking/Open311_ServiceType/doc/spec.md
@@ -48,13 +48,13 @@ FIWARE / OASC recommends the following additional fields as an extension to the 
     + Normative references: [https://schema.org/provider](https://schema.org/provider) 
     + Optional
 
-+ `dateCreated` : The date on which the service type was created. This date might be different than the entity creation date.
++ `dateCreated` : The date on which the service type was created.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateModified` : Last update date of this service type.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`

--- a/IssueTracking/Open311_ServiceType/doc/spec.md
+++ b/IssueTracking/Open311_ServiceType/doc/spec.md
@@ -48,11 +48,15 @@ FIWARE / OASC recommends the following additional fields as an extension to the 
     + Normative references: [https://schema.org/provider](https://schema.org/provider) 
     + Optional
 
-+ `dateCreated` : The date on which the service type was created.
++ `effectiveSince` : The date on which the service type was created. This date might be different than the entity creation date.
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Optional
+
++ `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
 
-+ `dateModified` : Last update date of this service type.
++ `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
 

--- a/KeyPerformanceIndicator/doc/spec.md
+++ b/KeyPerformanceIndicator/doc/spec.md
@@ -108,9 +108,9 @@ Example `KPI-2016-2018-Incidences-Street`.
             + Type: [DateTime](http://schema.org/DateTime)
     + Mandatory
     
-+ `dateCreated` : The date on which the organization created this KPI. This date might be different than the entity creation date.
++ `dateCreated` : The date on which the organization created this KPI.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateNextCalculation` : Date on which a new calculation of the KPI should be available.
     + Attribute type: [DateTime](https://schema.org/DateTime)
@@ -120,9 +120,9 @@ Example `KPI-2016-2018-Incidences-Street`.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
       
-+ `dateModified` : Last update date of the KPI data. This can be different than the last update date of the KPI's value.
++ `dateModified` : Last update date of the KPI data.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `location` :  Location of the area to which the KPI refers to. 
     + Attribute type: GeoJSON geometry. 

--- a/KeyPerformanceIndicator/doc/spec.md
+++ b/KeyPerformanceIndicator/doc/spec.md
@@ -108,7 +108,11 @@ Example `KPI-2016-2018-Incidences-Street`.
             + Type: [DateTime](http://schema.org/DateTime)
     + Mandatory
     
-+ `dateCreated` : The date on which the organization created this KPI.
++ `effectiveSince` : The date on which the organization created this KPI. This date might be different than the entity creation date.
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Optional
+
++ `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
 
@@ -120,7 +124,11 @@ Example `KPI-2016-2018-Incidences-Street`.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
       
-+ `dateModified` : Last update date of the KPI data.
++ `updateAt` : Last update date of the KPI data. This can be different than the last update date of the KPI's value.
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Optional
+
++ `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
     

--- a/KeyPerformanceIndicator/doc/spec.md
+++ b/KeyPerformanceIndicator/doc/spec.md
@@ -124,7 +124,7 @@ Example `KPI-2016-2018-Incidences-Street`.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
       
-+ `updateAt` : Last update date of the KPI data. This can be different than the last update date of the KPI's value.
++ `updatedAt` : Last update date of the KPI data. This can be different than the last update date of the KPI's value.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
 

--- a/Parking/OffStreetParking/doc/spec.md
+++ b/Parking/OffStreetParking/doc/spec.md
@@ -19,11 +19,11 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
    
 + `dateCreated` : Entity's creation timestamp
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `location` : Geolocation of the parking site represented by a GeoJSON (Multi)Polygon or Point.
     + Attribute type: `geo:json`.

--- a/Parking/OnStreetParking/doc/spec.md
+++ b/Parking/OnStreetParking/doc/spec.md
@@ -17,11 +17,11 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
 
 + `dateCreated` : Entity's creation timestamp
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `category` : Street parking category. 
     + Attribute type: List of [Text](http://schema.org/Text)

--- a/Parking/ParkingSpot/doc/spec.md
+++ b/Parking/ParkingSpot/doc/spec.md
@@ -15,11 +15,11 @@ Thus, an entity of type `ParkingSpot` cannot exist without a containing entity o
 
 + `dateCreated` : Entity creation date.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `name` : Name of this parking spot. It can denote the number or label used to identify it within a parking site.
     + Normative References: [https://schema.org/name](https://schema.org/name)

--- a/ParksAndGardens/FlowerBed/doc/spec.md
+++ b/ParksAndGardens/FlowerBed/doc/spec.md
@@ -15,11 +15,11 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `taxon` : Used to indicate the biological [taxon](http://en.wikipedia.org/wiki/en:taxon)
 to which the trees, or plants in the flower bed belong.

--- a/ParksAndGardens/Garden/doc/spec.md
+++ b/ParksAndGardens/Garden/doc/spec.md
@@ -15,11 +15,11 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `source` : A sequence of characters giving the source of the entity data.
     + Attribute type: [Text](https://schema.org/Text) or [URL](https://schema.org/URL)

--- a/ParksAndGardens/GreenspaceRecord/doc/spec.md
+++ b/ParksAndGardens/GreenspaceRecord/doc/spec.md
@@ -15,11 +15,11 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `source` : A sequence of characters giving the source of the entity data.
     + Attribute type: [Text](https://schema.org/Text) or [URL](https://schema.org/URL)

--- a/PointOfInterest/Beach/doc/spec.md
+++ b/PointOfInterest/Beach/doc/spec.md
@@ -18,11 +18,11 @@ any property specified by schema.org and which domain is `https://schema.org/Bea
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `source` : A sequence of characters giving the source of the entity data.
     + Attribute type: [Text](https://schema.org/Text) or [URL](https://schema.org/URL)

--- a/PointOfInterest/Museum/doc/spec.md
+++ b/PointOfInterest/Museum/doc/spec.md
@@ -18,11 +18,11 @@ any property specified by schema.org and which domain is `https://schema.org/Mus
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `source` : A sequence of characters giving the source of the entity data.
     + Attribute type: [Text](https://schema.org/Text) or [URL](https://schema.org/URL)

--- a/PointOfInterest/PointOfInterest/doc/spec.md
+++ b/PointOfInterest/PointOfInterest/doc/spec.md
@@ -17,11 +17,11 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `source` : A sequence of characters giving the source of the entity data.
     + Attribute type: [Text](https://schema.org/Text) or [URL](https://schema.org/URL)

--- a/StreetLighting/Streetlight/doc/spec.md
+++ b/StreetLighting/Streetlight/doc/spec.md
@@ -88,7 +88,7 @@ Typically it will contain an identifier that will allow to obtain more informati
     
 + `dateModified` : Timestamp of the last update made to this entity
     + Attribute Type: [DateTime](http://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `dateServiceStarted` : Date at which the streetlight started giving service.
     + Attribute Type: [Date](http://schema.org/Date)

--- a/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -66,7 +66,7 @@ responsible, district, neighbourhood, etc.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateServiceStarted` : Date at which the cabinet controller started giving service.
     + Attribute Type: [Date](http://schema.org/Date)

--- a/StreetLighting/StreetlightGroup/doc/spec.md
+++ b/StreetLighting/StreetlightGroup/doc/spec.md
@@ -84,7 +84,7 @@ responsible, district, neighbourhood, etc.
     
 + `dateModified` : Timestamp of the last update made to this entity.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
         
 + `description` : Description about the streetlight group. 
     + Normative References: [https://schema.org/description](https://schema.org/description)

--- a/Transportation/Bike/BikeHireDockingStation/doc/spec.md
+++ b/Transportation/Bike/BikeHireDockingStation/doc/spec.md
@@ -19,14 +19,14 @@ A JSON Schema corresponding to this data model can be found [here](https://fiwar
     +   Normative References:
         [http://schema.org/DateTime](http://schema.org/DateTime)[
         ](http://schema.org/DateTime)
-    +   Optional
+    +   Read-Only. Automatically generated.
 
 +   `dateModified` : Last update timestamp of this entity.
     +   Attribute type: [DateTime](https://schema.org/DateTime)
     +   Normative References:
         [http://schema.org/DateTime](http://schema.org/DateTime)[
         ](http://schema.org/DateTime)
-    +   Optional
+    +   Read-Only. Automatically generated.
 
 +   `location` : Geolocation of the station represented by a GeoJSON
     (Multi)Polygon or Point.

--- a/Transportation/Road/doc/spec.md
+++ b/Transportation/Road/doc/spec.md
@@ -21,11 +21,11 @@ This data model has been developed in cooperation with mobile operators and the 
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
         
 + `name` : Name given to this road, for instance `M-30`.
     + Normative References: [https://schema.org/name](https://schema.org/name)

--- a/Transportation/RoadSegment/doc/spec.md
+++ b/Transportation/RoadSegment/doc/spec.md
@@ -26,11 +26,11 @@ This data model has been developed in cooperation with mobile operators and the 
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `source` : The source of this data.
     + Attribute type: [URL](https://schema.org/URL)

--- a/Transportation/TrafficFlowObserved/doc/spec.md
+++ b/Transportation/TrafficFlowObserved/doc/spec.md
@@ -26,7 +26,7 @@ the Automotive and Smart City vertical segments and related IoT applications.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Mandatory
+    + Read-Only. Automatically generated.
         
 + `laneId` : Lane identifier.
     + Attribute type: [Number](https://schema.org/Number)
@@ -51,7 +51,7 @@ the lack of support of Orion Context Broker for datetime intervals, it can be us
     
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `name` : Name given to this observation.
     + Normative References: [https://schema.org/name](https://schema.org/name)

--- a/Transportation/Vehicle/Vehicle/doc/spec.md
+++ b/Transportation/Vehicle/Vehicle/doc/spec.md
@@ -187,11 +187,11 @@ responsible, district, neighbourhood, etc.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Creation timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`

--- a/Transportation/Vehicle/VehicleModel/doc/spec.md
+++ b/Transportation/Vehicle/VehicleModel/doc/spec.md
@@ -90,11 +90,11 @@ duration with the given vehicle (e.g. liters per 100 km).
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Creation timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`

--- a/User/Activity/doc/spec.md
+++ b/User/Activity/doc/spec.md
@@ -20,11 +20,11 @@ A JSON Schema corresponding to this data model can be found [here](https://fiwar
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional  
+    + Read-Only. Automatically generated.
 
 + `dateActivityStarted` : Activity's start timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)

--- a/User/UserContext/doc/spec.md
+++ b/User/UserContext/doc/spec.md
@@ -16,11 +16,11 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `refUser` : reference to the (anonymised) User to which this UserContext is associated.
     + Attribute type: [https://schema.org/URL](https://schema.org/URL)

--- a/WasteManagement/WasteContainer/doc/spec.md
+++ b/WasteManagement/WasteContainer/doc/spec.md
@@ -199,7 +199,7 @@ responsible, district, neighbourhood, etc.
 
 + `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `TimeInstant` : [Timestamp](https://github.com/telefonicaid/iotagent-node-lib#TimeInstant)
 saved by FIWARE's IoT Agent as per dynamic IoT data arrival. Note: This attribute has not been harmonized

--- a/WasteManagement/WasteContainerIsle/doc/spec.md
+++ b/WasteManagement/WasteContainerIsle/doc/spec.md
@@ -52,11 +52,11 @@ responsible, district, neighbourhood, etc.
     
 + `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
-+ `dateCreated` : Creation timestamp of the isle (This might different than the entity creation time)
++ `dateCreated` : Creation timestamp of the isle.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`

--- a/WasteManagement/WasteContainerIsle/doc/spec.md
+++ b/WasteManagement/WasteContainerIsle/doc/spec.md
@@ -54,9 +54,13 @@ responsible, district, neighbourhood, etc.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
 
-+ `dateCreated` : Creation timestamp of the isle.
++ `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
+
++ `availableSince` : Creation timestamp of the isle (This might different than the entity creation time)
+    + Attribute type: [DateTime](https://schema.org/DateTime)
+    + Optional
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`

--- a/Weather/WeatherForecast/doc/spec.md
+++ b/Weather/WeatherForecast/doc/spec.md
@@ -20,11 +20,11 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `name` : Name given to the weather forecast location.
     + Normative References: [https://schema.org/name](https://schema.org/name)

--- a/Weather/WeatherObserved/doc/spec.md
+++ b/Weather/WeatherObserved/doc/spec.md
@@ -15,11 +15,11 @@ A JSON Schema corresponding to this data model can be found [here](https://fiwar
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
     
 + `name` : Name given to the weather observed location.
     + Normative References: [https://schema.org/name](https://schema.org/name)

--- a/datamodel_template.md
+++ b/datamodel_template.md
@@ -14,11 +14,11 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional
+    + Read-Only. Automatically generated.
 
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional    
+    + Read-Only. Automatically generated.
 
 + `owner` : Entity's owners.
     + Attribute type: List of references to [Person]( http://schema.org/Person) or [Organization](https://schema.org/Organization).


### PR DESCRIPTION
This is a transversal change to all data models were dateCreated and dateModified are used. The changes in this PR are supported by this statement in the data model guidelines (https://github.com/Fiware/dataModels/tree/master/guidelines.md#date-attributes)

> `dateCreated` and `dateModified` are special entity attributes provided off-the-shelf by NGSIv2 implementations. Be careful because they can be different than the actual creation or update date of the real world entity represented by its corresponding digital entity.

Note that this PR affects only to the way in which these attribute/metadata has to be consumed but the syntax keep the same. In other words, no JSON Schema was changed in this PR.

Additional specific line-comments are provided. Please have a look to them.

CC: @jmcanterafonseca @manucarrace @mrutid