### PR TITLE
Fixed #286 - Incorrect Rendering of lists

### DIFF
--- a/specs/Device/Device/doc/spec.md
+++ b/specs/Device/Device/doc/spec.md
@@ -13,12 +13,14 @@ part of [ETSI](http://www.etsi.org) standards.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `Device`.
 
 + `category` : See attribute `category` from [DeviceModel](../../DeviceModel/doc/spec.md). Optional but recommended to optimize queries.
-        
+
 + `controlledProperty` : See attribute `controlledProperty` from [DeviceModel](../../DeviceModel/doc/spec.md). Optional but recommended to optimize queries.
 
 + `controlledAsset` : The asset(s) (building, object, etc.) controlled by the device.
@@ -35,33 +37,33 @@ and 3G / 4G public land mobile networks and some satellite mobile networks.
 + `mcc` : Mobile Country Code - This property identifies univoquely the country of the mobile network the device is attached to.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-    
+
 + `macAddress` : The MAC address of the device.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Optional
-    
-+ `ipAddress` : The IP address of the device. It can be a comma separated list of values if the device has more than one IP address. 
+
++ `ipAddress` : The IP address of the device. It can be a comma separated list of values if the device has more than one IP address.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Optional
 
 + `supportedProtocol` : See attribute `supportedProtocol` from [DeviceModel](../../DeviceModel/doc/spec.md). Needed if due to a software update
-new protocols are supported. Otherwise it is better to convey it at `DeviceModel` level. 
+new protocols are supported. Otherwise it is better to convey it at `DeviceModel` level.
 
 + `configuration` : Device's technical configuration. This attribute is intended to be a dictionary of properties which capture
 parameters which have to do with the configuration of a device (timeouts, reporting periods, etc.)
-and which are not currently covered by the standard attributes defined by this model. 
+and which are not currently covered by the standard attributes defined by this model.
     + Attribute type: [StructuredValue](https://schema.org/StructuredValue)
     + Attribute metadata:
         + `dateModified` :  Last update timestamp of this attribute.
             + Metadata type: [DateTime](https://schema.org/DateTime)
             + Read-Only. Automatically generated.
     + Optional
-    
-+ `location` : Location of this device represented by a GeoJSON geometry of type point. 
+
++ `location` : Location of this device represented by a GeoJSON geometry of type point.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Optional.
-    
+
 + `name` : A mnemonic name given to the device.
     + Normative References: [name](https://schema.org/name)
     + Optional
@@ -101,11 +103,11 @@ and which are not currently covered by the standard attributes defined by this m
 + `dateLastCalibration` : A timestamp which denotes when the last calibration of the device happened.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
-    
+
 + `serialNumber` : The serial number assigned by the manufacturer.
     + Normative References: [https://schema.org/serialNumber](https://schema.org/serialNumber)
     + Optional
-    
+
 + `provider` : The provider of the device.
     + Normative References: [https://schema.org/provider](https://schema.org/provider)
     + Optional
@@ -115,7 +117,7 @@ and which are not currently covered by the standard attributes defined by this m
     + Optional
 
 + `batteryLevel` : Device's battery level. It must be equal to `1.0` when battery is full. `0.0` when battery ìs empty.
-`null` when cannot be determined. 
+`null` when cannot be determined.
     + Type: [Number](https://schema.org/Number)
     + Allowed values: Interval [0,1]
     + Attribute metadata:
@@ -123,8 +125,8 @@ and which are not currently covered by the standard attributes defined by this m
         This value can also appear as a FIWARE [TimeInstant](https://github.com/telefonicaid/iotagent-node-lib#TimeInstant)
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
-+ `deviceState` : State of this device from an operational point of view. Its value can be vendor dependent.  
+
++ `deviceState` : State of this device from an operational point of view. Its value can be vendor dependent.
     + Type: [Text](https://schema.org/Text)
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
@@ -145,7 +147,7 @@ Obviously, in order to toggle the referred switch, this attribute value will hav
         This value can also appear as a FIWARE [TimeInstant](https://github.com/telefonicaid/iotagent-node-lib#TimeInstant)
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
@@ -194,4 +196,4 @@ T.B.D.
 
 + Is `function` really needed?
 + Do we need a `state` attribute as it happens in SAREF?
-+ Check consistency with oneM2M and SAREF ontologies. 
++ Check consistency with oneM2M and SAREF ontologies.

--- a/specs/Device/DeviceModel/doc/spec.md
+++ b/specs/Device/DeviceModel/doc/spec.md
@@ -2,18 +2,20 @@
 
 ## Description
 
-This entity captures the static properties of a Device. 
+This entity captures the static properties of a Device.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `DeviceModel`.
 
 + `category` : Device's category(ies).
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed values, one of the following or any other meaningful to the application:
-        + `sensor` : A device that detects and responds to events or changes in the physical environment such as light, motion, or temperature changes. 
+        + `sensor` : A device that detects and responds to events or changes in the physical environment such as light, motion, or temperature changes.
            [https://w3id.org/saref#Sensor](https://w3id.org/saref#Sensor).
         + `actuator` : A device responsible for moving or controlling a mechanism or system.
            [https://w3id.org/saref#Actuator](https://w3id.org/saref#Actuator).
@@ -26,9 +28,9 @@ This entity captures the static properties of a Device.
         + `multimedia` : A device designed to display, store, record or play multimedia content such as audio, images, animation, video.
            [https://w3id.org/saref#Multimedia](https://w3id.org/saref#Multimedia)
     + Mandatory
-    
+
 + `deviceClass` : Class of constrained device as specified by RFC 7228.
-If the device is not a constrained device this property can be left as `null` or undefined. 
+If the device is not a constrained device this property can be left as `null` or undefined.
     + Attribute type: [Text](https://schema.org/Text)
     + Normative References: [RFC7228](https://tools.ietf.org/html/rfc7228#section-3)
     + Allowed values: (`C0`, `C1`, `C2`)
@@ -48,19 +50,19 @@ If the device is not a constrained device this property can be left as `null` or
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed values: (`levelControl`, `sensing`, `onOff`, `openClose`, `metering`, `eventNotification`), from SAREF.
     + Optional
-    
+
 + `supportedProtocol` : Supported protocol(s) or networks.
     + Attribute type: List of [Text](https://schema.org/Text).
     + Allowed values: (`ul20`, `mqtt`, `lwm2m`, `http`, `websocket`, `onem2m`, `sigfox`, `lora`,
-    `nb-iot`, `ec-gsm-iot`, `lte-m`, `cat-m`, `3g`, `grps`)  or any other value meaningful for an application. 
+    `nb-iot`, `ec-gsm-iot`, `lte-m`, `cat-m`, `3g`, `grps`)  or any other value meaningful for an application.
     + Optional
-    
+
 + `supportedUnits` : Units of measurement supported by the device.
     + Attribute type: List of [Text](https://schema.org/Text).
     + Allowed values: The unit code (text) of measurement given using the
         [UN/CEFACT Common Code](http://wiki.goodrelations-vocabulary.org/Documentation/UN/CEFACT_Common_Codes) (max. 3 characters).
     + Optional
-    
+
 + `energyLimitationClass` : Device's class of energy limitation as per RFC 7228.
     + Attribute type: [Text](https://schema.org/Text)
     + Normative References: [RFC7228](https://tools.ietf.org/html/rfc7228#page-11)
@@ -85,7 +87,7 @@ If the device is not a constrained device this property can be left as `null` or
 + `name` : Name given to this device model.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
-    
+
 + `description` : Device's description
     + Normative References: [description](https://schema.org/description)
     + Optional

--- a/specs/Environment/NoiseLevelObserved/doc/spec.md
+++ b/specs/Environment/NoiseLevelObserved/doc/spec.md
@@ -7,7 +7,9 @@ This entity is primarily associated with the Smart City and environment vertical
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `NoiseLevelObserved`.
 
@@ -19,7 +21,7 @@ This entity is primarily associated with the Smart City and environment vertical
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
 
-+ `location` : Location of this observation represented by a GeoJSON geometry. 
++ `location` : Location of this observation represented by a GeoJSON geometry.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not present.
@@ -27,7 +29,7 @@ This entity is primarily associated with the Smart City and environment vertical
 + `address` : Civic address of this observation.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Mandatory if `location` is not present.
-    
+
 + `name` : Name given to this observation.
     + Normative References: [https://schema.org/name]
     + Optional
@@ -35,34 +37,34 @@ This entity is primarily associated with the Smart City and environment vertical
 + `description` : Description given to this observation.
     + Normative References: [https://schema.org/description]
     + Optional
-    
+
 + `dateObserved` : The date and time of this observation represented by an ISO8601 interval. As a workaround for
-the lack of support of Orion Context Broker for datetime intervals, it can be used two separate attributes: `dateObservedFrom`, `dateObservedTo`. 
-    + Attribute type: ISO8601 interval represented as [Text](https://schema.org/Text). 
+the lack of support of Orion Context Broker for datetime intervals, it can be used two separate attributes: `dateObservedFrom`, `dateObservedTo`.
+    + Attribute type: ISO8601 interval represented as [Text](https://schema.org/Text).
     + Optional
-        
-+ `dateObservedFrom` : Observation period start date and time. See `dateObserved`. 
-    + Attribute type: [DateTime](https://schema.org/DateTime). 
+
++ `dateObservedFrom` : Observation period start date and time. See `dateObserved`.
+    + Attribute type: [DateTime](https://schema.org/DateTime).
     + Mandatory
-    
-+ `dateObservedTo` : Observation period end date and time. See `dateObserved`. 
-    + Attribute type: [DateTime](https://schema.org/DateTime). 
+
++ `dateObservedTo` : Observation period end date and time. See `dateObserved`.
+    + Attribute type: [DateTime](https://schema.org/DateTime).
     + Mandatory
-    
+
 + `refDevice` : A reference to the device which captured this observation.
     + Attribute type: Reference to an entity of type `Device`
     + Optional
 
 + `sonometerClass` : Class of sonometer (0, 1, 2) according to [ANSI](http://soundmetersource.com/ansi-standards.html)
 used for taking this observation. This attribute is useful when no device entity is associated to observations.
-It allows to convey, roughly, information about the precision of the measurements. 
+It allows to convey, roughly, information about the precision of the measurements.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: one of (`"0"`, `"1"`, `"2"`)
     + Optional
-    
+
 + `refPointOfInterest` : A reference to a point of interest associated to this observation.
     + Attribute type: Reference to an entity of type `PointOfInterest`
-    + Optional    
+    + Optional
 
 ### Representing acoustic parameters
 
@@ -70,7 +72,7 @@ The number of acoustic parameters measured can vary. *For each* acoustic measura
 + Attribute name: Equal to the name of the measurand, for instance `LAeq`, `LAmax`.
 It must correspond to a term defined at [http://www.acoustic-glossary.co.uk/definitions-l.htm](http://www.acoustic-glossary.co.uk/definitions-l.htm), with the only exception that
 those measurands which name contains a `,` char, such char shall be substituded by the `_` char. For instance, the measurand "LAeq,d" shall be represented by an Attribute which
-name shall be `LAeq_d`. 
+name shall be `LAeq_d`.
 + Attribute type: [Number](https://schema.org/Number)
 + Attribute value: corresponds to the value for the measurand as a number expressed in decibels.
 + Attribute Metadata:

--- a/specs/IssueTracking/Open311_ServiceRequest/doc/spec.md
+++ b/specs/IssueTracking/Open311_ServiceRequest/doc/spec.md
@@ -5,11 +5,13 @@ the properties defined by Open 311 at [POST Service Request](http://wiki.open311
 and [GET Service Request](http://wiki.open311.org/GeoReport_v2/#get-service-request).
 
 Using this data model and a FIWARE NGSI version 2 implementation it is straightforward to implement
-a service compliant with the Open 311 specifications. 
+a service compliant with the Open 311 specifications.
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. It might be equal to a string representation of `service_request_id`. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier. It might be equal to a string representation of `service_request_id`.
 
 + `type` : It must be `Open311:ServiceRequest`.
 
@@ -26,7 +28,7 @@ The following fields defined by Open 311 are allowed to be attributes of this en
 + `description`
 
 + `agency_responsible`. Please note that this is semantically equivalent to the [provider](http://schema.org/provider)
-property (name subproperty) of schema.org. 
+property (name subproperty) of schema.org.
 
 + `service_notice`
 
@@ -64,18 +66,18 @@ property (name subproperty) of schema.org.
 
 + `account_id`
 
-+ `address`. If used it must be renamed to `open311:address`. 
++ `address`. If used it must be renamed to `open311:address`.
 
 *All attribute types must be coherent with the Open 311 definitions. Applications must use the types
-`Text`, `Number` and `DateTime` accordingly.* 
+`Text`, `Number` and `DateTime` accordingly.*
 
 To support FIWARE NGSI v2 geoqueries concerning Open311 Service Requests the following property must be added:
 
-+ `location` : Location of the area on which this service request is concerned. 
-    + Attribute type: GeoJSON geometry. 
++ `location` : Location of the area on which this service request is concerned.
+    + Attribute type: GeoJSON geometry.
     + Mandatory if the service request is geolocated.
-    
-    
+
+
 Additionally, applications might use the following standard schema.org structured properties:
 
 + [address](http://schema.org/address).
@@ -127,7 +129,7 @@ mode (`options=keyValues`).
       },
       "media_url":"http://exaple.org/media/638344.jpg"
     }
-    
+
 ## Test it with real services
 
-## Open issues   
+## Open issues

--- a/specs/IssueTracking/Open311_ServiceType/doc/spec.md
+++ b/specs/IssueTracking/Open311_ServiceType/doc/spec.md
@@ -8,7 +8,9 @@ the same property names and structure, although we strongly believe the Open311 
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : It must be `Open311:ServiceType`.
 
@@ -17,7 +19,7 @@ are allowed to be attributes of this entity type:
 
 + `jurisdiction_id`
 
-+ `type`. To avoid collision with the NGSI entity type it has been renamed to `open311:type`. 
++ `type`. To avoid collision with the NGSI entity type it has been renamed to `open311:type`.
 
 + `service_code`
 
@@ -31,21 +33,21 @@ are allowed to be attributes of this entity type:
 
 + `metadata`. This field is not strictly needed as the proposed entity encompasses the attribute definition as well.
 If defined, its value must be `true` if the `attributes` property is defined and its array value is not empty. Otherwise
-it must be equal to `false`. 
+it must be equal to `false`.
 
 
 + `attributes`. As per the [Service Definition](http://wiki.open311.org/GeoReport_v2/#get-service-definition)
-structure defined by Open 311. 
+structure defined by Open 311.
 
 
 FIWARE / OASC recommends the following additional fields as an extension to the Open 311 model:
 
-+ `location` :  Location of the area on which this type of service is provided. 
-    + Attribute type: GeoJSON geometry. 
-    + Optional 
++ `location` :  Location of the area on which this type of service is provided.
+    + Attribute type: GeoJSON geometry.
+    + Optional
 
 + `provider` :  Provider of the service.
-    + Normative references: [https://schema.org/provider](https://schema.org/provider) 
+    + Normative references: [https://schema.org/provider](https://schema.org/provider)
     + Optional
 
 + `effectiveSince` : The date on which the service type was created. This date might be different than the entity creation date.

--- a/specs/KeyPerformanceIndicator/doc/spec.md
+++ b/specs/KeyPerformanceIndicator/doc/spec.md
@@ -3,14 +3,16 @@
 According to [Wikipedia](https://en.wikipedia.org/wiki/Performance_indicator) a Key Performance Indicator (KPI)
 is a type of performance measurement. KPIs evaluate the success of an organization or of a particular activity in which it engages.
 
-The present data model defines a type of NGSI entity which captures the value and associated details of a key performance indicator. 
+The present data model defines a type of NGSI entity which captures the value and associated details of a key performance indicator.
 The data model is flexible enough to accomodate different usage scenarios: An entity  per KPI calculation
 or a unique entity per KPI which value evolves along time. Please note that in the latter case a historical module, such as the STH,
-would have to take care of the KPI evolution. 
+would have to take care of the KPI evolution.
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : It must be `KeyPerformanceIndicator`.
 
@@ -18,7 +20,7 @@ would have to take care of the KPI evolution.
 Example `KPI-2016-2018-Incidences-Street`.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
-    
+
 + `alternateName` : An alias for the KPI.
     + Normative References: [https://schema.org/alternateName](https://schema.org/alternateName)
     + Optional
@@ -26,31 +28,31 @@ Example `KPI-2016-2018-Incidences-Street`.
 + `organization` : Subject organization evaluated by the KPI.
     + Attribute Type: [Organization](https://schema.org/Organization)
     + Mandatory
-    
+
 + `process` :  Subject process evaluated by the KPI.
     + Attribute Type: [Text](http://schema.org/Text)
-    + Either `process` or `product` must be defined. 
+    + Either `process` or `product` must be defined.
 
 + `product` :  Subject *product or service* evaluated by the KPI.
     + Attribute Type: [Product](https://schema.org/Product)
-    + Either `process` or `product` must be defined.       
-    
+    + Either `process` or `product` must be defined.
+
 + `provider` :  Provider of the product or service, if any, that this KPI evaluates.
-    + Normative references: [https://schema.org/provider](https://schema.org/provider) 
-    + Optional   
-      
+    + Normative references: [https://schema.org/provider](https://schema.org/provider)
+    + Optional
+
 + `businessTarget` : For informative purposes, the business target to which this KPI is related to.
     + Attribute Type: [Text](http://schema.org/Text)
     + Optional
 
 + `description` : Indicator's description.
     + Normative References: [https://schema.org/description](https://schema.org/description)
-    + Optional 
+    + Optional
 
 + `calculationFrequency` : How often the KPI is calculated.
     + Attribute Type: [Text](http://schema.org/Text)
     + Allowed values: one Of (`hourly`, `daily`, `weekly`, `monthly`, `yearly`, `quarterly`, `bimonthly`, `biweekly`)
-        + Or any other value meaningful for the application and not covered by the above list. 
+        + Or any other value meaningful for the application and not covered by the above list.
     + Mandatory
 
 + `category` : Indicator's category.
@@ -59,9 +61,9 @@ Example `KPI-2016-2018-Incidences-Street`.
     `process`, `output`, `practical`, `directional`, `actionable`, `financial`).
     Check [Wikipedia](https://en.wikipedia.org/wiki/Performance_indicator#Categorization_of_indicators)
     for a description of each category listed above.
-        + Any other value meaningful to the application and not covered by the above list. 
+        + Any other value meaningful to the application and not covered by the above list.
     + Mandatory
-    
+
 + `calculatedBy` : The organization in charge of calculating the KPI.
     + Attribute Type: [Organization](https://schema.org/Organization)
     + Optional
@@ -69,9 +71,9 @@ Example `KPI-2016-2018-Incidences-Street`.
 + `calculationMethod` : The calculation method used.
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed values: oneOf ( `manual`, `automatic`, `semiautomatic`)
-        +  Any other value meaningful to the application and not covered by the above list. 
+        +  Any other value meaningful to the application and not covered by the above list.
     + Optional
-    
+
 + `calculationFormula` : For informative purposes, the formula used for calculating the indicator.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
@@ -102,12 +104,12 @@ Example `KPI-2016-2018-Incidences-Street`.
     + Optional
 
 + `kpiValue` :
-    + Attribute type: It can be of any type. 
+    + Attribute type: It can be of any type.
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Mandatory
-    
+
 + `effectiveSince` : The date on which the organization created this KPI. This date might be different than the entity creation date.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
@@ -123,7 +125,7 @@ Example `KPI-2016-2018-Incidences-Street`.
 + `dateExpires` : The date on which the KPI will be no longer necessary or meaningful.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
-      
+
 + `updatedAt` : Last update date of the KPI data. This can be different than the last update date of the KPI's value.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
@@ -131,15 +133,15 @@ Example `KPI-2016-2018-Incidences-Street`.
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-    
-+ `location` :  Location of the area to which the KPI refers to. 
-    + Attribute type: GeoJSON geometry. 
-    + Optional 
 
-+ `address` :  Civic address of the area to which the KPI refers to. 
++ `location` :  Location of the area to which the KPI refers to.
+    + Attribute type: GeoJSON geometry.
+    + Optional
+
++ `address` :  Civic address of the area to which the KPI refers to.
     + Attribute type: [https://schema.org/PostalAddress](https://schema.org/PostalAddress)
     + Optional
-    
+
 + `area` : For organizational purposes, it allows to add extra textual geographical information such as district, burough, or any other
 hint which can help to identify the KPI coverage.
     + Attribute type: [Text](http://schema.org/Text)

--- a/specs/Parking/OffStreetParking/doc/spec.md
+++ b/specs/Parking/OffStreetParking/doc/spec.md
@@ -13,10 +13,12 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `OffStreetParking`.
-   
+
 + `dateCreated` : Entity's creation timestamp
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
@@ -24,16 +26,16 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
 + `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-    
+
 + `location` : Geolocation of the parking site represented by a GeoJSON (Multi)Polygon or Point.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined.
-    
+
 + `address` : Registered parking site civic address.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Mandatory if `location` is not defined.
-    
+
 + `name` : Name given to the parking site.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
@@ -42,7 +44,7 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
 Particularities and detailed descriptions should be found under the corresponding specific attributes.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values:
-        + (`public`, `private`, `publicPrivate`,  
+        + (`public`, `private`, `publicPrivate`,
            `urbanDeterrentParking`, `parkingGarage`, `parkingLot`,
            `shortTerm`, `mediumTerm`, `longTerm`,
            `free`, `feeCharged`,
@@ -50,14 +52,14 @@ Particularities and detailed descriptions should be found under the correspondin
            `onlyResidents`, `onlyWithPermit`,
            `forEmployees`, `forVisitors`, `forCustomers`, `forStudents`, `forMembers`, `forDisabled`, `forResidents`,
            `underground`, `ground`)
-        + The semantics of the `forxxx` values is that the parking offers specific spots subject to that particular condition. 
-        + The semantics of the `onlyxxx`values is that the parking only allows to park on that particular condition. 
+        + The semantics of the `forxxx` values is that the parking offers specific spots subject to that particular condition.
+        + The semantics of the `onlyxxx`values is that the parking only allows to park on that particular condition.
         + Other application-specific
     + Mandatory
-    
+
 + `allowedVehicleType` : Vehicle type(s) allowed. The first element of this array *MUST* be the principal
 vehicle type allowed. Free spot numbers of other allowed vehicle types might be reported under the attribute `extraSpotNumber`
-and through specific entities of type *ParkingGroup*. 
+and through specific entities of type *ParkingGroup*.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed Values: The following values defined by *VehicleTypeEnum*,
     [DATEX 2 version 2.3](http://www.datex2.eu/sites/www.datex2.eu/files/DATEXIISchema_2_2_2_1.zip):
@@ -66,33 +68,33 @@ and through specific entities of type *ParkingGroup*.
            `motorcycle`, `motorcycleWithSideCar`,
            `motorscooter`, `tanker`, `trailer`, `van`, `anyVehicle`)
     + Mandatory
-    
-+ `chargeType` : Type(s) of charge performed by the parking site. 
+
++ `chargeType` : Type(s) of charge performed by the parking site.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: Some of those defined by the DATEX II version 2.3 *ChargeTypeEnum* enumeration:
         + (`flat`, `minimum`, `maximum`, `additionalIntervalPrice` `seasonTicket` `temporaryPrice` `firstIntervalPrice`,
         `annualPayment`, `monthlyPayment`, `free`, `other`)
         + Any other application-specific
     + Mandatory
-    
+
 + `requiredPermit` : This attribute captures what permit(s) might be needed to park at this site. Semantics
 is that at least *one of* these permits is needed to park. When a permit is composed by more than one item (and)
 they can be combined with a ",". For instance "residentPermit,disabledPermit" stays that both, at the same time,
-a resident and a disabled permit are needed to park. If empty or `null`, no permit is needed. 
+a resident and a disabled permit are needed to park. If empty or `null`, no permit is needed.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: The following, defined by the *PermitTypeEnum* enumeration of DATEX II version 2.3.
         + oneOf (`employeePermit`, `studentPermit`, `fairPermit`, `governmentPermit`,  `residentPermit`,
         `specificIdentifiedVehiclePermit`, `visitorPermit`, `noPermitNeeded`)
         + Any other application-specific
     + Mandatory
-    
+
 + `occupancyDetectionType` : Occupancy detection method(s).
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: The following from DATEX II version 2.3 *OccupancyDetectionTypeEnum*:
         + (`none`, `balancing`, `singleSpaceDetection`, `modelBased`, `manual`)
         + Or any other application-specific
-    + Mandatory    
-    
+    + Mandatory
+
 + `acceptedPaymentMethod` : Accepted payment method(s).
     + Normative references: https://schema.org/acceptedPaymentMethod
     + Optional
@@ -100,30 +102,30 @@ a resident and a disabled permit are needed to park. If empty or `null`, no perm
 + `priceRatePerMinute` : Price rate per minute.
     + Attribute type: [Number](https://schema.org/Number)
     + Optional
-    
+
 + `priceCurrency` : Price currency of price rate per minute.
     + Attribute type: [Text](http://schema.org/Text)
-    + Normative references: [https://schema.org/priceCurrency](https://schema.org/priceCurrency) 
-    + Optional    
-      
-+ `description` : Description about the parking site. 
+    + Normative references: [https://schema.org/priceCurrency](https://schema.org/priceCurrency)
+    + Optional
+
++ `description` : Description about the parking site.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `image` : A URL containing a photo of this parking site.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
- 
-+ `layout` : Parking layout. Gives more details to the `category` attribute. 
+
++ `layout` : Parking layout. Gives more details to the `category` attribute.
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed values:  As per the *ParkingLayoutEnum* of DATEX II version 2.3:
         + one Of (`automatedParkingGarage`, `surface`, `multiStorey`, `singleLevel`, `multiLevel`,
         `openSpace`, `covered`, `nested`, `field`, `rooftop`,
-        `sheds`, `carports`, `garageBoxes`, `other`). See also [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Tag:amenity%3Dparking). 
+        `sheds`, `carports`, `garageBoxes`, `other`). See also [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Tag:amenity%3Dparking).
         + Or any other value useful for the application and not covered above.
     + Optional
-    
-+ `usageScenario` : Usage scenario(s). Gives more details to the `category` attribute. 
+
++ `usageScenario` : Usage scenario(s). Gives more details to the `category` attribute.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: Those defined by the enumeration *ParkingUsageScenarioEnum* of DATEX II version 2.3:
         + (`truckParking`, `parkAndRide`, `parkAndCycle`,	`parkAndWalk`, `kissAndRide`, `	liftshare`, `carSharing`,
@@ -131,13 +133,13 @@ a resident and a disabled permit are needed to park. If empty or `null`, no perm
             `staffGuidesToSpace`,  `vehicleLift`, `loadingBay`, `dropOff`, `overnightParking`, `other`)
         + Or any other value useful for the application and not covered above.
     + Optional
-    
+
 + `parkingMode` : Parking mode(s).
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: Those defined by the DATEX II version 2.3 *ParkingModeEnum* enumeration:
         + (`perpendicularParking`, `parallelParking`, `echelonParking`)
     + Optional
-    
+
 + `facilities` : Facilities provided by this parking site.
     + Attributes: List of [Text](http://schema.org/Text)
     + Allowed values: The following defined by the *EquipmentTypeEnum* enumeration of DATEX II version 2.3:
@@ -147,34 +149,34 @@ a resident and a disabled permit are needed to park. If empty or `null`, no perm
         `defibrillator`, `firstAidEquipment` `fireHose` `fireExtinguisher` `fireHydrant`)
         + Any other application-specific
     + Optional
-    
+
 + `security` : Security aspects provided by this parking site.
     + Attributes: List of [Text](http://schema.org/Text)
     + Allowed values: The following, some of them, defined by *ParkingSecurityEnum* of DATEX II version 2.3:
         + (`patrolled`, `securityStaff`, `externalSecurity`, `cctv`, `dog`, `guard24hours`, `lighting`, `floodLight`, `fences`
         `areaSeperatedFromSurroundings`)
         + Any other application-specific
-    + Optional    
-    
+    + Optional
+
 + `highestFloor` : For parking sites with multiple floor levels, highest floor.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: An integer number. 0 is ground level. Upper floors are positive numbers. Lower floors are negative ones. 
+    + Allowed values: An integer number. 0 is ground level. Upper floors are positive numbers. Lower floors are negative ones.
     + Optional
-    
+
 + `lowestFloor` : For parking sites with multiple floor levels, lowest floor.
     + Attribute type: [Number](http://schema.org/Number)
     + Allowed values: An integer number.
     + Optional
-    
+
 + `maximumParkingDuration` : Maximum allowed stay at site, on a general basis, encoded as a ISO8601 duration.
-A `null` or empty value indicates an indefinite duration.  
+A `null` or empty value indicates an indefinite duration.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
-    
-+ `totalSpotNumber` : The total number of spots offered by this parking site. 
+
++ `totalSpotNumber` : The total number of spots offered by this parking site.
 This number can be difficult to be obtained for those parking locations on which spots are not clearly marked by lines.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: Any positive integer number or 0. 
+    + Allowed values: Any positive integer number or 0.
     + Normative references: DATEX 2 version 2.3 attribute *parkingNumberOfSpaces* of the *ParkingRecord* class.
     + Optional
 
@@ -182,28 +184,28 @@ This number can be difficult to be obtained for those parking locations on which
 such as those for disabled people, long term parkers and so on).
 This might be harder to estimate at those parking locations on which spots borders are not clearly marked by lines.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: A positive integer number, including 0. It must lower or equal than `totalSpotNumber`. 
+    + Allowed values: A positive integer number, including 0. It must lower or equal than `totalSpotNumber`.
     + Metadata:
         + `timestamp` : Timestamp of the last attribute update
         + Type: [DateTime](https://schema.org/DateTime)
     + Optional
-        
+
 + `extraSpotNumber` : The number of extra spots *available*, i.e. free. This value must aggregate free spots from all groups mentioned below:
 A/ Those reserved for special purposes and usually require a permit. Permit details will be found at
 parking group level (entity of type `ParkingGroup`).
 B/ Those reserved for other vehicle types different than the principal allowed vehicle type.
 C/ Any other group of parking spots not subject to the general condition rules conveyed by this entity.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: A positive integer number, including 0. 
+    + Allowed values: A positive integer number, including 0.
     + Metadata:
         + `timestamp` : Timestamp of the last attribute update
         + Type: [DateTime](https://schema.org/DateTime)
     + Optional
-       
+
 + `openingHours` : Opening hours of the parking site.
     + Normative references:  [http://schema.org/openingHours](http://schema.org/openingHours)
     + Optional
-    
+
 + `firstAvailableFloor` : Number of the floor closest to the ground which currently has available parking spots.
     + Attribute type: [Number](http://schema.org/Number)
     + Metadata:
@@ -211,7 +213,7 @@ C/ Any other group of parking spots not subject to the general condition rules c
         + Type: [DateTime](https://schema.org/DateTime)
     + Allowed values: Stories are numbered between -n and n, being 0 ground floor.
     + Optional
-            
+
 + `specialLocation` : If the parking site is at a special location (airport, depatment store, etc.)
 it conveys what is such special location.
     + Attribute type: [Text](http://schema.org/Text)
@@ -221,8 +223,8 @@ it conveys what is such special location.
         `campground`, `themePark`, `ferryTerminal`, `vehicleOnRailTerminal`, `coachStation`, `cableCarStation`, `publicTransportStation`,
         `market`, `religiousCentre`, `conventionCentre`, `cinema`, `skilift`, `hotel`, `other`)
     + Optional
-    
-+ `status` : Status of the parking site. 
+
++ `status` : Status of the parking site.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Metadata:
         + `timestamp` : Timestamp of the last attribute update
@@ -244,19 +246,19 @@ it conveys what is such special location.
 + `owner` : Parking site's owner.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
-         
+
 + `provider` : Parking site service provider.
     + Normative references: [https://schema.org/provider](https://schema.org/provider)
     + Optional
-	
+
 + `measuresPeriod` : The measures period related to availableSpotNumber and priceRatePerMinute.
     + Attribute type: [Number](http://schema.org/Number)
     + Optional
-    
+
 + `measuresPeriodUnit` : The measures period unit related to availableSpotNumber and priceRatePerMinute.
     + Attribute type: [unitText](http://schema.org/unitText)
-    + Optional	
-    
+    + Optional
+
 + `contactPoint` : Parking site contact point.
     + Normative references: [https://schema.org/contactPoint](https://schema.org/contactPoint)
     + Optional
@@ -276,31 +278,31 @@ all the zones.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Meters
     + Optional
-    
+
 + `maximumAllowedWidth` : Maximum allowed width for vehicles. If there are multiple zones, it will be the minimum width of
-all the zones. 
+all the zones.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Meters
-    + Optional    
+    + Optional
 
 + `refParkingAccess` : Parking site's access point(s).
     + Attribute type: List of references to [ParkingAccess](../../ParkingAccess/doc/spec.md)
     + Optional
-       
-+ `refParkingGroup` : Parking site's identified group(s). A group can correspond to a zone, a complete storey, a group of spots, etc. 
+
++ `refParkingGroup` : Parking site's identified group(s). A group can correspond to a zone, a complete storey, a group of spots, etc.
     + Attribute type: List of references to [ParkingGroup](../../ParkingGroup/doc/spec.md)
     + Optional
-    
-+ `refParkingSpot` : Individual parking spots belonging to this offstreet parking site.  
+
++ `refParkingSpot` : Individual parking spots belonging to this offstreet parking site.
     + Attribute type: List of references to [ParkingSpot](../../ParkingSpot/doc/spec.md)
-    + Optional    
-    
+    + Optional
+
 + `areaServed` : Area served by this parking site. Precise semantics can depend on the application or target city.
  For instance, it can be a neighbourhood, burough or district.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
-    
-+ `aggregateRating` : Aggregated rating for this parking site. 
+
++ `aggregateRating` : Aggregated rating for this parking site.
     + Normative References: [https://schema.org/aggregateRating](https://schema.org/aggregateRating)
     + Optional
 
@@ -316,29 +318,29 @@ mode (`options=keyValues`).
     "type": "OffStreetParking",
     "category": {
         "value": [
-            "underground", 
-            "public", 
-            "feeCharged", 
-            "mediumTerm", 
+            "underground",
+            "public",
+            "feeCharged",
+            "mediumTerm",
             "barrierAccess"
         ]
-    }, 
+    },
     "layout": {
         "value": [
             "multiLevel"
         ]
-    }, 
+    },
     "name": {
         "value": "Parque de estacionamento Trindade"
-    }, 
+    },
     "requiredPermit": {
         "value": []
-    }, 
+    },
     "allowedVehicleType": {
         "value": [
             "car"
         ]
-    }, 
+    },
     "availableSpotNumber": {
         "value": 132,
         "metadata": {
@@ -347,40 +349,40 @@ mode (`options=keyValues`).
                 "value": "2018-09-21T12:00:00"
             }
         }
-    }, 
+    },
     "totalSpotNumber": {
         "value": 414
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
+            "type": "Point",
             "coordinates": [
-                -8.60961198807, 
+                -8.60961198807,
                 41.150691773
             ]
         }
-    }, 
+    },
     "chargeType": {
         "value": [
             "temporaryPrice"
         ]
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "Porto", 
-            "addressCountry": "Portugal", 
+            "addressLocality": "Porto",
+            "addressCountry": "Portugal",
             "streetAddress": "Rua de Fernandes Tom\u00e1s"
         }
-    }, 
+    },
     "maximumParkingDuration": {
         "value": "PT8H"
-    }, 
+    },
     "dateModified": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-06-02T09:25:55.00Z"
-    }, 
+    },
     "description": {
         "value": "Municipal car park located near the Trindade metro station and the Town Hall"
     }
@@ -389,7 +391,7 @@ mode (`options=keyValues`).
 
 ## Examples of use 2
 
-A public off street parking underground controlled by a barrier. 
+A public off street parking underground controlled by a barrier.
 
     {
       "id": "porto-ParkingLot-23889",
@@ -415,8 +417,8 @@ A public off street parking underground controlled by a barrier.
       "description": "Municipal car park located near the Trindade metro station and the Town Hall",
       "dateModified": "2016-06-02T09:25:55.00Z"
     }
-    
-Urban Deterrent (xxxx and ride) parking. Free. 2 hours at a maximum. 
+
+Urban Deterrent (xxxx and ride) parking. Free. 2 hours at a maximum.
 
     {
        "id": "pdu-valladolid-1",
@@ -437,12 +439,12 @@ Urban Deterrent (xxxx and ride) parking. Free. 2 hours at a maximum.
       }
     }
 
-Long stay parking. Maximum 4 days. Charging depends on time spent. 
+Long stay parking. Maximum 4 days. Charging depends on time spent.
 
     {
       "id": "long-stay-valladolid-2",
       "type": "OffStreetParking",
-      "name": "El Corte Ingles", 
+      "name": "El Corte Ingles",
       "usageScenario": ["overnight"],
       "category": ["public", "longTerm", "underground", "parkingGarage"],
       "layout": ["singleLevel"],
@@ -457,7 +459,7 @@ Long stay parking. Maximum 4 days. Charging depends on time spent.
       }
     }
 
-Off street parking with an specific area devoted to residents (100 spots). 
+Off street parking with an specific area devoted to residents (100 spots).
 
     {
        "id": "parking-example-234",
@@ -475,14 +477,14 @@ Off street parking with an specific area devoted to residents (100 spots).
 
 Two different groups are needed:
 
-1/ Subrogated parking group to denote regular parking spots. 
+1/ Subrogated parking group to denote regular parking spots.
 
-    { 
+    {
       "id": "example-234-g-regular",
       "type": "ParkingGroup",
-      "name": "La Farola 1 - Público General", 
-      "chargeType": ["temporaryPrice"],       
-      "category": ["offstreet", "shortTerm"],  
+      "name": "La Farola 1 - Público General",
+      "chargeType": ["temporaryPrice"],
+      "category": ["offstreet", "shortTerm"],
       "totalSpotNumber": 150,
       "availableSpotNumber": 40,
       "requiredPermit": null,
@@ -492,12 +494,12 @@ Two different groups are needed:
       /* Other required fields (Check model) */
     }
 
-2/ Subrogated parking group to denote those parking spots devoted for residents. 
+2/ Subrogated parking group to denote those parking spots devoted for residents.
 
-    { 
+    {
       "id": "example-234-g-residents",
       "type": "ParkingGroup",
-      "name": "La Farola 1 - Residentes", 
+      "name": "La Farola 1 - Residentes",
       "chargeType": ["annualTax"],   /* Annual payment for residents */
       "category": ["offstreet", "longTerm", "onlyResidents"], /* Group Category. Overwrites parent's */
       "totalSpotNumber": 100,
@@ -509,8 +511,8 @@ Two different groups are needed:
       /* Other required fields (Check model) */
     }
 
-Private parking only for employees. A devoted visitor zone. 
-  
+Private parking only for employees. A devoted visitor zone.
+
     {
       "id": "district-telefonica-parking-1",
       "type": "OffStreetParking",
@@ -542,8 +544,8 @@ Two different groups are needed:
       "refParkingSite": "district-telefonica-parking-1",
       "allowedVehicleType": "car"
       /* Other required fields (Check model) */
-    }    
-    
+    }
+
 2/ Subrogated parking group modelling visitor's spots.
 
     {

--- a/specs/Parking/OnStreetParking/doc/spec.md
+++ b/specs/Parking/OnStreetParking/doc/spec.md
@@ -11,7 +11,9 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `OnStreetParking`.
 
@@ -22,8 +24,8 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
 + `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-    
-+ `category` : Street parking category. 
+
++ `category` : Street parking category.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values:
         + (`forDisabled`, `forResidents`, `forLoadUnload`, `onlyWithPermit`, `forELectricalCharging`)
@@ -33,12 +35,12 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
         + (`shortTerm`, `mediumTerm`)
         + Any value not covered by the above enumeration and meaningful for the application.
     + Mandatory
-          
+
 + `location` : Geolocation of the parking site represented by a GeoJSON (Multi)Polygon.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
-    + Mandatory if `address`is not defined. 
-    
+    + Mandatory if `address`is not defined.
+
 + `address` : Registered onstreet parking civic address.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Mandatory if location not defined
@@ -47,18 +49,18 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
 
-+ `chargeType` : Type of charge(s) performed by the parking site. 
++ `chargeType` : Type of charge(s) performed by the parking site.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: Some of those defined by the DATEX II version 2.3 *ChargeTypeEnum* enumeration:
         + (`flat`, `minimum`, `maximum`, `additionalIntervalPrice` `seasonTicket` `temporaryPrice` `firstIntervalPrice`,
         `annualPayment`, `monthlyPayment`, `free`, `unknown`, `other`)
         + Any other application-specific
     + Mandatory
-    
+
 + `requiredPermit` : This attribute captures what permit(s) might be needed to park at this site. Semantics
 is that at least *one of* these permits is needed to park. When a permit is composed by more than one item (and)
 they can be combined with a ",". For instance "residentPermit,disabledPermit" stays that both, at the same time,
-a resident and a disabled permit are needed to park. If empty or `null`, no permit is needed. 
+a resident and a disabled permit are needed to park. If empty or `null`, no permit is needed.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: The following, defined by the *PermitTypeEnum* enumeration of DATEX II version 2.3.
         + oneOf (`fairPermit`, `governmentPermit`,  `residentPermit`,
@@ -66,17 +68,17 @@ a resident and a disabled permit are needed to park. If empty or `null`, no perm
         `carSharingPermit`, `emergencyVehiclePermit`, `maintenanceVehiclePermit`, `roadWorksPermit`,
         `taxiPermit`, `transportationPermit`, `noPermitNeeded`)
         + Any other application-specific
-    + Mandatory. It can be `null`. 
-    
+    + Mandatory. It can be `null`.
+
 + `permitActiveHours` : This attribute allows to capture situations when a permit is only needed at specific hours or days of week.
 It is an structured value which must contain a subproperty per each required permit, indicating when the permit is active.
-If nothing specified (or `null`) for a permit it will mean that a permit is always required. `null`or empty object means always active. 
+If nothing specified (or `null`) for a permit it will mean that a permit is always required. `null`or empty object means always active.
 The syntax must be conformant with schema.org (opening hours specification)[https://schema.org/openingHours]. For instance,
-        a blue zone which is only active on dayweeks will be encoded as "blueZonePermit": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00". 
+        a blue zone which is only active on dayweeks will be encoded as "blueZonePermit": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00".
     + Attribute type: [StructuredValue](http://schema.org/StructuredValue)
-    + Mandatory. It can be `null`.     
-    
-+ `allowedVehicleType` : Vehicle type allowed (only one per on street parking). 
+    + Mandatory. It can be `null`.
+
++ `allowedVehicleType` : Vehicle type allowed (only one per on street parking).
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed Values: The following values defined by *VehicleTypeEnum*
     [DATEX 2 version 2.3](http://www.datex2.eu/sites/www.datex2.eu/files/DATEXIISchema_2_2_2_1.zip) :
@@ -86,11 +88,11 @@ The syntax must be conformant with schema.org (opening hours specification)[http
     + Mandatory
 
 + `maximumParkingDuration` : Maximum allowed stay at site encoded as a ISO8601 duration.
-A `null` or empty value indicates an indefinite duration.  
+A `null` or empty value indicates an indefinite duration.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
-    
-+ `usageScenario` : Usage scenario. Gives more details about the `category` attribute. 
+
++ `usageScenario` : Usage scenario. Gives more details about the `category` attribute.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: Those defined by the enumeration *ParkingUsageScenarioEnum* of DATEX II version 2.3:
         + (`parkAndRide`, `parkAndCycle`,	`parkAndWalk`, `kissAndRide`, `	liftshare`, `carSharing`,
@@ -98,18 +100,18 @@ A `null` or empty value indicates an indefinite duration.
         + Or any other value useful for the application and not covered above.
     + Optional
 
-+ `description` : Description about the onstreet parking zone. 
++ `description` : Description about the onstreet parking zone.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `areBordersMarked` : Denotes whether parking spots are delimited (with blank lines or similar) or not.
     + Attribute type: [Boolean](https://schema.org/Boolean)
     + Optional
 
-+ `totalSpotNumber` : The total number of spots offered by this parking site. 
++ `totalSpotNumber` : The total number of spots offered by this parking site.
 This number can be difficult to be obtained for those parking locations on which spots are not clearly marked by lines.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: Any positive integer number or 0. 
+    + Allowed values: Any positive integer number or 0.
     + Normative references: DATEX 2 version 2.3 attribute *parkingNumberOfSpaces* of the *ParkingRecord* class.
     + Optional
 
@@ -117,29 +119,29 @@ This number can be difficult to be obtained for those parking locations on which
 long term parkers and so on.
 This might be harder to estimate at those parking locations on which spots borders are not clearly marked by lines.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: A positive integer number, including 0. It must lower or equal than `totalSpotNumber`. 
+    + Allowed values: A positive integer number, including 0. It must lower or equal than `totalSpotNumber`.
     + Metadata:
         + `timestamp` : Timestamp of the last attribute update
         + Type: [DateTime](https://schema.org/DateTime)
     + Optional
-        
+
 + `extraSpotNumber` : The number of extra spots *available*, i.e. free. Extra spots are those reserved for special purposes and usually require
 a permit. Permit details will be found at parking group level (entity of type `ParkingGroup`).
 This value must aggregate free spots from all groups devoted to special parking conditions.
     + Attribute type: [Number](http://schema.org/Number)
     + Allowed values: A positive integer number, including 0. `extraSpotNumber` plus `availableSpotNumber` must be lower than or
-    equal to `totalSpotNumber`. 
+    equal to `totalSpotNumber`.
     + Metadata:
         + `timestamp` : Timestamp of the last attribute update
         + Type: [DateTime](https://schema.org/DateTime)
-    
+
 + `occupancyDetectionType` : Occupancy detection method(s).
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: The following from DATEX II version 2.3 *OccupancyDetectionTypeEnum*:
         + (`none`, `balancing`, `singleSpaceDetection`, `modelBased`, `manual`)
         + Or any other application-specific
     + Mandatory
-        
+
 + `parkingMode` : Parking mode(s).
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: Those defined by the DATEX II version 2.3 *ParkingModeEnum* enumeration:
@@ -159,23 +161,23 @@ This value must aggregate free spots from all groups devoted to special parking 
 + `acceptedPaymentMethod` : Accepted payment method(s)
     + Normative references: https://schema.org/acceptedPaymentMethod
     + Optional
-    
+
 + `image` : A URL containing a photo of this parking site.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
 
-+ `refParkingSpot` : Individual parking spots belonging to this on street parking site.  
++ `refParkingSpot` : Individual parking spots belonging to this on street parking site.
     + Attribute type: List of references to [ParkingSpot](../../ParkingSpot/doc/spec.md)
     + Optional
-    
+
 + `refParkingGroup` : Reference to the parking group(s) (if any) belonging to this onstreet parking zone.
     + Attribute type: List of references to [ParkingGroup](../../ParkingGroup/doc/spec.md)
     + Optional
-    
+
 + `areaServed` : Area served by this onstreet parking. Precise semantics can depend on the application or target city.
  For instance, it can be a neighbourhood, burough or district.
     + Attribute type: [Text](http://schema.org/Text)
-    + Optional    
+    + Optional
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`
@@ -185,87 +187,87 @@ mode (`options=keyValues`).
 
 ```json
 {
-    "id": "santander:daoiz_velarde_1_5", 
+    "id": "santander:daoiz_velarde_1_5",
     "type": "OnStreetParking",
     "category": {
         "value": [
-            "blueZone", 
-            "shortTerm", 
+            "blueZone",
+            "shortTerm",
             "forDisabled"
         ]
-    }, 
+    },
     "permitActiveHours": {
         "value": {
             "blueZonePermit": "Mo, Tu, We, Th, Fr, Sa 09:00-20:00"
         }
-    }, 
+    },
     "requiredPermit": {
         "value": [
-            "blueZonePermit", 
+            "blueZonePermit",
             "disabledPermit"
         ]
-    }, 
+    },
     "allowedVehicleType": {
         "value": "car"
-    }, 
+    },
     "chargeType": {
         "value": [
             "temporaryFee"
         ]
-    }, 
+    },
     "refParkingGroup": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": [
-            "daoiz-velarde-1-5-main", 
+            "daoiz-velarde-1-5-main",
             "daoiz-velarde-1-5-disabled"
         ]
-    }, 
+    },
     "totalSpotNumber": {
         "value": 6
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Polygon", 
+            "type": "Polygon",
             "coordinates": [
                 [
                     [
-                        -3.80356167695194, 
+                        -3.80356167695194,
                         43.46296641666926
-                    ], 
+                    ],
                     [
-                        -3.803161973253841, 
+                        -3.803161973253841,
                         43.46301091092682
-                    ], 
+                    ],
                     [
-                        -3.803147082548618, 
+                        -3.803147082548618,
                         43.462879859445884
-                    ], 
+                    ],
                     [
-                        -3.803536474744068, 
+                        -3.803536474744068,
                         43.462838666196674
-                    ], 
+                    ],
                     [
-                        -3.80356167695194, 
+                        -3.80356167695194,
                         43.46296641666926
                     ]
                 ]
             ]
         }
-    }, 
+    },
     "areaServed": {
         "value": "Zona Centro"
-    }, 
+    },
     "maximumAllowedStay": {
         "value": "PT2H"
-    }, 
+    },
     "dateModified": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-06-02T09:25:55.00Z"
-    }, 
+    },
     "extraSpotNumber": {
         "value": 2
-    }, 
+    },
     "availableSpotNumber": {
         "value": 3,
         "metadata": {
@@ -281,9 +283,9 @@ mode (`options=keyValues`).
 ## Examples of use 2
 
 An on street parking which contains a group of parking spots reserved for disabled people.
-At root entity level is announced that special parking spots for disabled are present and two of them free. 
+At root entity level is announced that special parking spots for disabled are present and two of them free.
 
-Main `OnstreetParking` entity. 
+Main `OnstreetParking` entity.
 
 ```
     {
@@ -337,7 +339,7 @@ A/ Subrogated `ParkingGroup` which gives details about the regular parking spots
     }
 ```
 
-B/ Subrogated `ParkingGroup`. `refPArkingSite` is a pointer to the root entity. All the parking spots are free. 
+B/ Subrogated `ParkingGroup`. `refPArkingSite` is a pointer to the root entity. All the parking spots are free.
 
 ```
     {

--- a/specs/Parking/ParkingAccess/doc/spec.md
+++ b/specs/Parking/ParkingAccess/doc/spec.md
@@ -2,11 +2,13 @@
 
 ## Description
 
-Represents an access point to a parking site, normally an offstreet parking. 
+Represents an access point to a parking site, normally an offstreet parking.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `ParkingAccess`.
 
@@ -14,7 +16,7 @@ Represents an access point to a parking site, normally an offstreet parking.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
-    
+
 + `address` : Registered civic address of the access point.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Optional
@@ -23,7 +25,7 @@ Represents an access point to a parking site, normally an offstreet parking.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Optional
 
-+ `description` : Description of the access point. 
++ `description` : Description of the access point.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
 
@@ -36,25 +38,25 @@ Represents an access point to a parking site, normally an offstreet parking.
 + `refOffStreetParking` : The offstreet parking site this access point gives access to.
     + Attribute type: Reference to an entity of type [OffStreetParking](../../OffStreetParking/doc/spec.md)
     + Mandatory
-    
+
 + `features` : Equipment or facilities provided by the access point.
     + Attribute type: List of [https://schema.org/Text](https://schema.org/Text)
     + Allowed values: Those specified by the DATEX II *AccessEquipmentEnum* and by *AccessibilityEnum*.
         + Other values meaningful to the application.
     + Optional
-    
+
 + `image` : A URL containing a photo of this access point.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
-    
+
 + `width` : Width of the access point.
     + Normative References: [https://schema.org/width](https://schema.org/width)
     + Optional
-    
+
 + `height` : Height of the access point.
     + Normative References: [https://schema.org/height](https://schema.org/height)
     + Optional
-    
+
 + `slope` : Slope of the access point (in relative terms).
     + Attribute Type: [Number](https://schema.org/Number)
     + Attribute Value: A number between 0 and 1.
@@ -69,29 +71,29 @@ mode (`options=keyValues`).
 ```json
 {
     "id": "accesspoint-trinidade-1",
-    "type": "ParkingAccess", 
+    "type": "ParkingAccess",
     "category": {
         "value": [
             "vehicleEntrance"
         ]
-    }, 
+    },
     "name": {
         "value": "Trinidade main entrance"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
+            "type": "Point",
             "coordinates": [
-                -8.60961198807, 
+                -8.60961198807,
                 41.150691773
             ]
         }
-    }, 
+    },
     "refOffStreetParking": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "porto-OffStreetParking-23889"
-    }, 
+    },
     "features": {
         "value": [
             "barrier"
@@ -101,7 +103,7 @@ mode (`options=keyValues`).
 ```
 
 ## Examples of use 2 (?options=keyValues simplified representation for data consumers)
-  
+
     {
       "id": "accesspoint-trinidade-1",
       "type": "ParkingAccess",
@@ -114,9 +116,8 @@ mode (`options=keyValues`).
       "refOffStreetParking": "porto-OffStreetParking-23889",
       "features": ["barrier"]
     }
-  
+
   ## Test it with a real service
-  
-  
+
+
   ## Open issues
-  

--- a/specs/Parking/ParkingGroup/doc/spec.md
+++ b/specs/Parking/ParkingGroup/doc/spec.md
@@ -6,18 +6,20 @@ A group of parking spots. Granularity level can vary.
 It can be an storey on a parking garage, an specific zone belonging to a big parking lot,  or just a group of spots intended
 for parking a certain vehicle type or subject to certain restrictions (disabled, residents, ...).
 For the sake of simplicity only one vehicle type per parking group is allowed. Similarly, one required permit is only allowed
-per group type. 
+per group type.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `ParkingGroup`.
 
-+ `category` : Parking Group's category. 
++ `category` : Parking Group's category.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values:
-        + `onstreet` if the parking group belongs to an `OnStreetParking`. 
+        + `onstreet` if the parking group belongs to an `OnStreetParking`.
         + `offstreet` if the parking group belongs to an `OffStreetParking`.
         + (`adjacentSpaces`, `nonAdjacentSpaces`, `completeFloor`, `statisticsOnly`,
            `vehicleTypeSpaces`, `particularConditionsSpaces`)
@@ -30,10 +32,10 @@ per group type.
 
 + `refParkingSite` : Parking site to which this zone belongs to. A group cannot be orphan. A group cannot have subgroups.
     + Attribute type: Reference to an [OffStreetParking](../../OffStreetParking/doc/spec.md) or to an
-    [OnStreetParking](../../OnStreetParking/doc/spec.md) entity. 
+    [OnStreetParking](../../OnStreetParking/doc/spec.md) entity.
     + Mandatory
-    
-+ `allowedVehicleType` : Vehicle type allowed (a parking group only allows one vehicle type). 
+
++ `allowedVehicleType` : Vehicle type allowed (a parking group only allows one vehicle type).
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed Values: The following values defined by *VehicleTypeEnum*
     [DATEX 2 version 2.3](http://www.datex2.eu/sites/www.datex2.eu/files/DATEXIISchema_2_2_2_1.zip) :
@@ -41,13 +43,13 @@ per group type.
            `carWithCaravan`, `carWithTrailer`, `constructionOrMaintenanceVehicle`, `lorry`, `moped`, `motorcycle`,
            `motorcycleWithSideCar`, `motorscooter`, `tanker`, `trailer`, `van`, `anyVehicle`)
     + Mandatory
-       
+
 + `location` : Geolocation of the parking group represented by a GeoJSON (Multi)Polygon or Point.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Optional
 
-+ `address` : Registered parking group civic address. 
++ `address` : Registered parking group civic address.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Optional
 
@@ -55,12 +57,12 @@ per group type.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Optional
 
-+ `description` : Description about the parking group. 
++ `description` : Description about the parking group.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
 
 + `maximumParkingDuration` : Maximum allowed stay encoded as a ISO8601 duration (`null` if indefinite).
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
 
@@ -71,11 +73,11 @@ Applications *SHOULD* inspect the value of this property at parent's level if it
         `annualPayment`, `monthlyPayment`, `free`, `other`)
         + Any other application-specific
     + Mandatory
-    
+
 + `requiredPermit` : This attribute captures what permit is needed to park in any of the spots of this group. For the
 sake of simplicity only one permit can be associated to a parking group. When a permit is composed by more than one item
 they can be combined by separating them with a ",". For instance "residentPermit,disabledPermit" stays that both
-a resident and a disabled permit are needed to park. If empty or `null`, no permit is needed. 
+a resident and a disabled permit are needed to park. If empty or `null`, no permit is needed.
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed values: The following, defined by the *PermitTypeEnum* enumeration of DATEX II version 2.3.
         + oneOf (`employeePermit`, `studentPermit`, `fairPermit`, `governmentPermit`,  `residentPermit`, `specificIdentifiedVehiclePermit`,
@@ -84,80 +86,80 @@ a resident and a disabled permit are needed to park. If empty or `null`, no perm
         `maintenanceVehiclePermit`, `roadWorksPermit`, `taxiPermit`, `transportationPermit`, `noPermitNeeded`)
         + Any other application-specific
     + Mandatory
-    
+
 + `permitActiveHours` : This attribute allows to capture situations when a permit is only needed at specific hours or days of week.
 It is an structured value which must contain a subproperty per each required permit, indicating when the permit is active.
-If nothing specified (or `null`) for a permit it will mean that a permit is always required. `null`or empty object means always active. 
+If nothing specified (or `null`) for a permit it will mean that a permit is always required. `null`or empty object means always active.
 The syntax must be conformant with schema.org [opening hours specification](https://schema.org/openingHours). For instance,
         a blue zone which is only active on dayweeks will be encoded as "blueZonePermit": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00".
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [StructuredValue](http://schema.org/StructuredValue)
-    + Mandatory. It can be `null`. 
+    + Mandatory. It can be `null`.
 
 + `reservationType` : Conditions for reservation.
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed values: The following specified by *ReservationTypeEnum* of DATEX II version 2.3:
         + one Of (`optional`, `mandatory`, `notAvailable`, `partly`).
     + Optional
-   
+
 + `areBordersMarked` : Denotes whether parking spots are delimited (with blank lines or similar) or not.
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [Boolean](https://schema.org/Boolean)
     + Optional
 
-+ `totalSpotNumber` : The total number of spots pertaining to this group. 
++ `totalSpotNumber` : The total number of spots pertaining to this group.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: Any positive integer number or 0. 
+    + Allowed values: Any positive integer number or 0.
     + Normative references: DATEX 2 version 2.3 attribute *parkingNumberOfSpaces* of the *ParkingRecord* class.
     + Optional
 
 + `availableSpotNumber` : The number of spots available in this group.
     + Attribute type: [Number](http://schema.org/Number)
-    + Allowed values: A positive integer number, including 0. It must lower or equal than `totalSpotNumber`. 
+    + Allowed values: A positive integer number, including 0. It must lower or equal than `totalSpotNumber`.
     + Metadata:
         + `timestamp` : Timestamp of the last attribute update
         + Type: [DateTime](https://schema.org/DateTime)
     + Optional
-            
+
 + `occupancyDetectionType` : Occupancy detection method.
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed values: The following from DATEX II version 2.3 *OccupancyDetectionTypeEnum*:
         + (`none`, `balancing`, `singleSpaceDetection`, `modelBased`, `manual`)
         + Or any other application-specific
     + Mandatory
-    
+
 + `parkingMode` : Parking mode(s).
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: Those defined by the DATEX II version 2.3 *ParkingModeEnum* enumeration:
         + (`perpendicularParking`, `parallelParking`, `echelonParking`)
     + Optional
 
 + `averageSpotWidth` : The average width of parking spots.
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Meters
     + Optional
 
 + `averageSpotLength` : The average length of parking spots.
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Meters
     + Optional
 
 + `maximumAllowedHeight` : Maximum allowed height for vehicles.
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Meters
     + Optional
 
 + `maximumAllowedWidth` : Maximum allowed width for vehicles.
-Applications *SHOULD* inspect the value of this property at parent's level if it is not defined. 
+Applications *SHOULD* inspect the value of this property at parent's level if it is not defined.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Meters
     + Optional
-    
+
 + `image` : A URL containing a photo of this parking group.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
@@ -175,27 +177,27 @@ mode (`options=keyValues`).
 ```json
 {
     "id": "daoiz-velarde-1-5-disabled",
-    "type": "ParkingGroup",  
+    "type": "ParkingGroup",
     "category": {
         "value": [
-            "onstreet", 
-            "adjacentSpaces", 
+            "onstreet",
+            "adjacentSpaces",
             "onlyDisabled"
         ]
-    }, 
+    },
     "refParkingSite": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "daoiz-velarde-1-5"
-    }, 
+    },
     "permitActiveHours": {
         "value": "null"
-    }, 
+    },
     "requiredPermit": {
         "value": "disabledPermit"
-    }, 
+    },
     "allowedVehicleType": {
         "value": "car"
-    }, 
+    },
     "availableSpotNumber": {
         "value": 1,
         "metadata": {
@@ -204,45 +206,45 @@ mode (`options=keyValues`).
                 "value": "2018-09-12T12:00:00"
             }
         }
-    }, 
+    },
     "totalSpotNumber": {
         "value": 2
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Polygon", 
+            "type": "Polygon",
             "coordinates": [
                 [
                     [
-                        -3.80356167695194, 
+                        -3.80356167695194,
                         43.46296641666926
-                    ], 
+                    ],
                     [
-                        -3.803161973253841, 
+                        -3.803161973253841,
                         43.46301091092682
-                    ], 
+                    ],
                     [
-                        -3.803147082548618, 
+                        -3.803147082548618,
                         43.462879859445884
-                    ], 
+                    ],
                     [
-                        -3.803536474744068, 
+                        -3.803536474744068,
                         43.462838666196674
-                    ], 
+                    ],
                     [
-                        -3.80356167695194, 
+                        -3.80356167695194,
                         43.46296641666926
                     ]
                 ]
             ]
         }
-    }, 
+    },
     "chargeType": {
         "value": [
             "free"
         ]
-    }, 
+    },
     "description": {
         "value": "Two parking spots reserved for disabled people"
     }
@@ -251,7 +253,7 @@ mode (`options=keyValues`).
 
 ## Examples of use 2 (?options=keyValues simplified representation for data consumers)
 
-A group of parking spots especially for disabled people. 
+A group of parking spots especially for disabled people.
 
     {
       "id": "daoiz-velarde-1-5-disabled",
@@ -278,8 +280,8 @@ A group of parking spots especially for disabled people.
       "requiredPermit": "disabledPermit",
       "permitActiveHours": null          /* Always permit is needed */
     }
-    
-A group of parking spots especially for loading and unloading goods. From 10:00 to 14:00, Monday-Saturday. 
+
+A group of parking spots especially for loading and unloading goods. From 10:00 to 14:00, Monday-Saturday.
 
     {
       "id": "daoiz-velarde-23-load",

--- a/specs/Parking/ParkingSpot/doc/spec.md
+++ b/specs/Parking/ParkingSpot/doc/spec.md
@@ -9,6 +9,8 @@ Thus, an entity of type `ParkingSpot` cannot exist without a containing entity o
 
 ## Data Model
 
+The data model is defined as shown below:
+
 + `id` : Entity's unique identifier.
 
 + `type` : Entity type. It must be equal to `ParkingSpot`.
@@ -32,7 +34,7 @@ Thus, an entity of type `ParkingSpot` cannot exist without a containing entity o
 + `location` : Geolocation of the parking spot, represented by a GeoJSON Point.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
-    + Mandatory. Not nullable (if `address` is not defined).  
+    + Mandatory. Not nullable (if `address` is not defined).
 
 + `address` : Registered parking spot civic address.
     + Normative References: [https://schema.org/address](https://schema.org/address)
@@ -49,7 +51,7 @@ Thus, an entity of type `ParkingSpot` cannot exist without a containing entity o
         saved by FIWARE's IoT Agents. Note: This attribute has not been harmonized
 to keep backwards compatibility with current FIWARE reference implementations.
             + Type: [DateTime]((https://schema.org/DateTime). here can be production environmments where the attribute type
-    is equal to the `ISO8601` string. If so, it must be considered as a synonym of `DateTime`.  
+    is equal to the `ISO8601` string. If so, it must be considered as a synonym of `DateTime`.
             + Optional
     + Mandatory
 
@@ -63,7 +65,7 @@ to keep backwards compatibility with current FIWARE reference implementations.
 
 + `refParkingGroup` : Group to which the parking spot belongs to. For model simplification purposes
 only one group is allowed per parking spot.
-    + Attribute type: Reference to an entity of type `ParkingGroup`.  
+    + Attribute type: Reference to an entity of type `ParkingGroup`.
     + Optional
 
 + `refParkingSite` : Parking site to which the the parking spot belongs to.
@@ -83,7 +85,7 @@ only one group is allowed per parking spot.
 saved by FIWARE's IoT Agent. Note: This attribute has not been harmonized
 to keep backwards compatibility with current FIWARE reference implementations.
     + Attribute type: [DateTime](https://schema.org/DateTime). There can be production environmments where the attribute type
-    is equal to the `ISO8601` string. If so, it must be considered as a synonym of `DateTime`.  
+    is equal to the `ISO8601` string. If so, it must be considered as a synonym of `DateTime`.
     + Optional
 
 + `refDevice` : The device representing the physical sensor used to monitor this parking spot.
@@ -108,29 +110,29 @@ mode (`options=keyValues`).
                 "value": "2018-09-21T12:00:00"
             }
         }
-    }, 
+    },
     "category": {
         "value": [
             "onstreet"
         ]
-    }, 
+    },
     "refParkingSite": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "santander:daoiz_velarde_1_5"
-    }, 
+    },
     "name": {
         "value": "A-13"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
+            "type": "Point",
             "coordinates": [
-                -3.80356167695194, 
+                -3.80356167695194,
                 43.46296641666926
             ]
         }
-    } 
+    }
 }
 ```
 

--- a/specs/PointOfInteraction/SmartPointOfInteraction/doc/spec.md
+++ b/specs/PointOfInteraction/SmartPointOfInteraction/doc/spec.md
@@ -9,7 +9,9 @@ The data model includes information regarding the area/surface covered by the te
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `SmartPointOfInteraction`.
 
@@ -17,27 +19,27 @@ The data model includes information regarding the area/surface covered by the te
     + Attribute type: List of [Text](http://schema.org/Text)
     + Allowed values: `information`, `entertainment`, `infotainment`, `co-creation` or any other extended value defined by the application.
     + Mandatory
-    
+
 + `areaCovered` : Defines the area covered by the Smart Point of Interaction using geoJSON format. It can be represented by a feature of type `Polygon` or `Multipolygon`.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
-    + Optional    
-    
+    + Optional
+
 + `applicationUrl` : This field specifies the real URL containing the solution or application (information, co-creation, etc) while the SmartSpot 'announcedUrl' field specifies the broadcasted URL which could be this same URL or a shortened one.
     + Attribute type: [URL](https://schema.org/URL)
-    + Mandatory    
+    + Mandatory
 
-+ `availability`: Specifies the time intervals in which this interactive service is generally available. It is noteworthy that Smart Spots have their own real availability in order to allow advanced configurations. The syntax must be conformant with schema.org [openingHours specification](https://schema.org/openingHours). For instance, a service which is only active on dayweeks will be encoded as "availability": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00". 
++ `availability`: Specifies the time intervals in which this interactive service is generally available. It is noteworthy that Smart Spots have their own real availability in order to allow advanced configurations. The syntax must be conformant with schema.org [openingHours specification](https://schema.org/openingHours). For instance, a service which is only active on dayweeks will be encoded as "availability": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00".
     + Attribute type: [Text](https://schema.org/Text)
     + Mandatory. It can be `null`.
 
 + `refRelatedEntity` : List of entities improved with this Smart Point of Interaction. The entity type could be any such as a “Parking”, “Point of Interest”, etc.
     + Attribute type: List of references to entities.
-    + Optional    
+    + Optional
 
 + `refSmartSpot` : References to the “Smart Spot” devices which are part of the Smart Point of Interaction.
     + Attribute type: Reference to one or more entities of type [SmartSpot](../../SmartSpot/doc/spec.md)
-    + Optional    
+    + Optional
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`
@@ -50,13 +52,13 @@ mode (`options=keyValues`).
   "id": "SPOI-ES-4326",
   "type": "SmartPointOfInteraction",
   "category": ["co-creation"],
-  "areaCovered": {                           
+  "areaCovered": {
     "type": "Polygon",
     "coordinates": [[
       [25.774, -80.190],
-      [18.466, -66.118], 
-      [32.321, -64.757], 
-      [25.774, -80.190] 
+      [18.466, -66.118],
+      [32.321, -64.757],
+      [25.774, -80.190]
     ]]
   },
   "applicationUrl": "http://www.example.org",

--- a/specs/PointOfInteraction/SmartSpot/doc/spec.md
+++ b/specs/PointOfInteraction/SmartSpot/doc/spec.md
@@ -8,35 +8,37 @@ In addition to the presented data model, this entity type inherits from the [Dev
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `SmartSpot`.
 
 + `announcedUrl` : URL broadcasted by the device.
     + Attribute type: [URL](https://schema.org/URL)
-    + Mandatory    
+    + Mandatory
 
 + `signalStrenght` : Signal strength to adjust the announcement range.
     + Attribute type: [Text](https://schema.org/Text)
-    + Allowed values: "lowest", "medium" or "highest". 
-    + Mandatory    
+    + Allowed values: "lowest", "medium" or "highest".
+    + Mandatory
 
 + `bluetoothChannel` : Bluetooth channels where to transmit the announcement.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: "37", "38", "39", "37,38", "38,39", "37,39" or "37,38,39".
-    + Mandatory  
+    + Mandatory
 
 + `coverageRadius` : Radius of the spot coverage area in meters.
     + Attribute Type: [Number](https://schema.org/Number)
     + Default unit: Meters.
-    + Optional      
+    + Optional
 
 + `announcementPeriod` : Period between announcements.
     + Attribute Type: [Number](https://schema.org/Number)
     + Default unit: Milliseconds.
-    + Mandatory     
+    + Mandatory
 
-+ `availability`: Specifies the functionality intervals in which the announcements will be sent. The syntax must be conformant with schema.org [openingHours specification](https://schema.org/openingHours). For instance, a service which is only active on dayweeks will be encoded as "availability": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00". 
++ `availability`: Specifies the functionality intervals in which the announcements will be sent. The syntax must be conformant with schema.org [openingHours specification](https://schema.org/openingHours). For instance, a service which is only active on dayweeks will be encoded as "availability": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00".
     + Attribute type: [Text](https://schema.org/Text)
     + Mandatory. It can be `null`.
 
@@ -63,7 +65,7 @@ mode (`options=keyValues`).
   "refSmartPointOfInteraction": "SPOI-ES-4326"
 }
 ```
-    
+
 ## Use it with a real service
 
 T.B.D.

--- a/specs/StreetLighting/Streetlight/doc/spec.md
+++ b/specs/StreetLighting/Streetlight/doc/spec.md
@@ -2,47 +2,49 @@
 
 An entity of type `Streetlight` represents a urban streetlight. Actually, there will be an entity of type `Streetlight` per lamp. Thus,
 if a particular pole holds more than one lantern there will be as many streetlight entites as installed lamps. As a result there might be more than
-one streetlight entity per location. 
+one streetlight entity per location.
 A `Steeetlight` entity does not contain any attribute corresponding to structural characteristics.
 Such data is captured by entities of type `StreetlightModel`.
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : It must be equal to `Streetlight`.
 
-+ `location` : Streetlight's location represented by a GeoJSON Point. 
++ `location` : Streetlight's location represented by a GeoJSON Point.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
     + Mandatory if `address` is not present.
-    
-+ `address` : Civic address where the streetlight is located. 
+
++ `address` : Civic address where the streetlight is located.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Mandatory if `location` is not present.
-    
+
 + `areaServed` : Higher level area to which this streetlight belongs to. It can be used to group streetlights per
 responsible, district, neighbourhood, etc.
     + Attribute type: [Text](https://schema.org/Text)
-    + Optional 
+    + Optional
 
 + `circuit` : The circuit to which this streetlight connects to and gets power from.
-Typically it will contain an identifier that will allow to obtain more information about such circuit. 
+Typically it will contain an identifier that will allow to obtain more information about such circuit.
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
 
-+ `refStreetlightModel` : Streetlight's model. 
++ `refStreetlightModel` : Streetlight's model.
     + Attribute type : Reference to a [StreetlightModel](../../StreetlightModel/doc/spec.md) entity.
     + Optional
-    
+
 + `refStreetlightControlCabinet` : If this streetlight is individually controlled, reference to the control cabinet in charge of.
     + Attribute type : Reference to a [StreetlightControlCabinet](../../StreetlightControlCabinet/doc/spec.md) entity.
     + Optional
 
-+ `status` : The overall status of this street light. 
++ `status` : The overall status of this street light.
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed values: one Of (`ok`, `defectiveLamp`, `columnIssue`, `brokenLantern`)
-        + Or any other value meaningful to the application and not covered by the values above. 
+        + Or any other value meaningful to the application and not covered by the values above.
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
@@ -55,18 +57,18 @@ Typically it will contain an identifier that will allow to obtain more informati
             + Type: [DateTime](http://schema.org/DateTime)
     + Allowed values: one Of (`on`, `off`, `low`, `bootingUp`)
     + Optional
-    
-+ `refStreetlightGroup` : Streetlight's group, if this streetlight belongs to any group. 
+
++ `refStreetlightGroup` : Streetlight's group, if this streetlight belongs to any group.
     + Attribute type : Reference to a [StreetlightGroup](../../StreetlightGroup/doc/spec.md) entity.
     + Optional
 
-+ `dateLastLampChange` : Timestamp of the last change of lamp made. If `null` it will mean that the lamp has never been changed. 
++ `dateLastLampChange` : Timestamp of the last change of lamp made. If `null` it will mean that the lamp has never been changed.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
         + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `dateLastSwitchingOn` : Timestamp of the last switching on.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
@@ -85,20 +87,20 @@ Typically it will contain an identifier that will allow to obtain more informati
     + Attribute type: [Text](http://schema.org/Text)
     + Allowed values: one Of (`group`, `individual`)
     + Optional
-    
+
 + `dateModified` : Timestamp of the last update made to this entity
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Read-Only. Automatically generated.
-    
+
 + `dateServiceStarted` : Date at which the streetlight started giving service.
     + Attribute Type: [Date](http://schema.org/Date)
     + Optional
-       
+
 + `image` : A URL containing a photo of the streetlight.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
-    
-+ `description` : Description about the streetlight. 
+
++ `description` : Description about the streetlight.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
 
@@ -110,12 +112,12 @@ Typically it will contain an identifier that will allow to obtain more informati
     + Attribute type:
     + Allowed values: oneOf (`façade`, `sidewalk`, `pedestrianPath`, `road`, `playground`,
     `park`, `garden`, `bridge`, `tunnel`, `parking`, `centralIsland`)
-        + Or any other value with semantics not covered by the above list. 
+        + Or any other value with semantics not covered by the above list.
 
 + `lanternHeight` : Lantern's height. In columns with many arms this can vary between streetlights. Another variation source
-of this property are wall-mounted streetlights. 
+of this property are wall-mounted streetlights.
     + Attribute type: [Number](https://schema.org/Number)
-    + Default unit: Meters. 
+    + Default unit: Meters.
     + Optional
 
 + `illuminanceLevel` : Relative illuminance level setting.
@@ -125,7 +127,7 @@ of this property are wall-mounted streetlights.
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`

--- a/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -4,29 +4,31 @@ It represents equipment, usually on street, used to the automated control of a g
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : It must be equal to `StreetlightControlCabinet`.
 
-+ `location` : Control cabinet's location represented by a GeoJSON point. 
++ `location` : Control cabinet's location represented by a GeoJSON point.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
     + Mandatory
 
-+ `address` : Civic address where the control cabinet is located. 
++ `address` : Civic address where the control cabinet is located.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Mandatory if `location` is not present.
-        
+
 + `areaServed` : Higher level area to which the cabinet belongs to. It can be used to group per
 responsible, district, neighbourhood, etc.
     + Normative References: [https://schema.org/areaServed](https://schema.org/areaServed)
     + Optional
-    
+
 + `serialNumber` : Serial number of the control cabinet.
     + Normative References: [https://schema.org/serialNumber](https://schema.org/serialNumber)
-    + Optional   
+    + Optional
 
-+ `refStreetlightGroup` : Streetlight group(s) controlled. 
++ `refStreetlightGroup` : Streetlight group(s) controlled.
     + Attribute type: List of references to entities of type [StreetlightGroup](../../StreetlightGroup/doc/spec.md).
     + Mandatory
 
@@ -45,21 +47,21 @@ responsible, district, neighbourhood, etc.
     + See also: [https://schema.org/model](https://schema.org/manufacturer)
     + Optional
 
-+ `cupboardMadeOf` : Material the cabinet's cupboard is made of. 
++ `cupboardMadeOf` : Material the cabinet's cupboard is made of.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: one Of (`plastic`, `metal`, `concrete`, `other`)
     + Optional
 
-+ `features` : A list of cabinet controller features. 
++ `features` : A list of cabinet controller features.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed Values: Those technical values considered meaningful by applications.
-        + `astronomicalClock` .- The control cabinet includes an astronomical clock to deal with switching hours. 
-        + `individualControl` .- The control cabinet allows to control street lights individually. 
+        + `astronomicalClock` .- The control cabinet includes an astronomical clock to deal with switching hours.
+        + `individualControl` .- The control cabinet allows to control street lights individually.
 
 + `compliantWith`. A list of standards to which the cabinet controller is compliant with (ex. `IP54`)
     + AttributeType: List of [Text](https://schema.org/Text).
     + Optional
-    
+
 + `annotations` : A field reserved for annotations (incidences, remarks, etc.).
     + Attribute type: List of [Text](https://schema.org/Text)
     + Optional
@@ -75,29 +77,29 @@ responsible, district, neighbourhood, etc.
 + `dateLastProgramming` : Date at which there was a programming operation over the cabinet.
     + Attribute Type: [Date](http://schema.org/DateTime)
     + Optional
-    
+
 + `nextActuationDeadline` : Deadline for next actuation to be performed (programming, testing, etc.).
     + Attribute Type: [DateTime](http://schema.org/DateTime)
-    + Optional   
+    + Optional
 
-+ `responsible` : Responsible for the cabinet controller, i.e. entity in charge of actuating (programming, etc.). 
++ `responsible` : Responsible for the cabinet controller, i.e. entity in charge of actuating (programming, etc.).
     + Attribute type: [Text](http://schema.org/Text)
     + Optional
 
 + `workingMode` : Working mode for this cabinet controller.
     + Attribute type: [Text](http://schema.org/Text)
-    + Allowed values: 
+    + Allowed values:
         + `automatic` : The cabinet controller decides automatically when light groups are switched on and off.
-        Manual operation is not allowed. 
-        + `manual` : Human intervention is required for switching on and off. 
-        + `semiautomatic` : The same as `automatic` but in this case manual intervention is allowed. 
-    + Mandatory 
+        Manual operation is not allowed.
+        + `manual` : Human intervention is required for switching on and off.
+        + `semiautomatic` : The same as `automatic` but in this case manual intervention is allowed.
+    + Mandatory
 
 + `maximumPowerAvailable` : The maximum power available (by contract) for the circuits controlled by this cabinet.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Kilowatts (kW)
     + Optional
-    
+
 + `energyConsumed` :  Energy consumed by the circuits controlled since metering started (since `dateMeteringStarted`).
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: Kilowatts per hour (kWh).
@@ -105,7 +107,7 @@ responsible, district, neighbourhood, etc.
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `energyCost` : Cost of the energy consumed by the circuits controlled since the metering start date (`dateMeteringStarted`).
     + Attribute type: [Number](https://schema.org/Number)
     + Default currency: Euros. (Other currencies might be expressed using a metadata attribute)
@@ -113,7 +115,7 @@ responsible, district, neighbourhood, etc.
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `reactiveEnergyConsumed` : Energy consumed (with regards to reactive power) by circuits
 since the metering start date (`dateMeteringStarted`).
     + Attribute type: [Number](https://schema.org/Number)
@@ -122,10 +124,10 @@ since the metering start date (`dateMeteringStarted`).
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `dateMeteringStarted` : The starting date for metering energy consumed.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
-    + Mandatory if `energyConsumed` is present.     
+    + Mandatory if `energyConsumed` is present.
 
 + `lastMeterReading` : Value of the last reading obtained from the energy consumed metering system.
     + Attribute type: [Number](https://schema.org/Number)
@@ -134,34 +136,34 @@ since the metering start date (`dateMeteringStarted`).
         + `timestamp`: Timestamp which reflects the date and time at which the referred reading was obtained.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `meterReadingPeriod` : The periodicity of energy consumed meter readings in days.
     + Attribute Type: [Number](http://schema.org/Number)
     + Optional
-    
+
 + `frequency` : The working frequency of the circuit.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: Hertz (Hz)
     + Optional
-        
+
 + `totalActivePower` : Active power currently consumed (counting all phases).
     + Attribute Type: [Number](http://schema.org/Number)
-    + Default unit: KiloWatts (kW). 
+    + Default unit: KiloWatts (kW).
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `totalReactivePower` : Reactive power currently consumed (counting all phases).
     + Attribute Type: [Number](http://schema.org/Number)
-    + Default unit: KiloVolts-Ampere-Reactive (kVArh). 
+    + Default unit: KiloVolts-Ampere-Reactive (kVArh).
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
 + `activePower` : Active power consumed  per phase. The actual values will be conveyed
-by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T. 
+by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: Kilowatts (kW)
     + Attribute metadata:
@@ -171,14 +173,14 @@ by subproperties which name will be equal to the name of each of the alternating
 
 + `reactivePower` : Reactive power. The actual values will be conveyed
 by subproperties which name will be equal to the name of each of the alternating
-current phases, typically R, S, T. 
+current phases, typically R, S, T.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: KiloVolts-Ampere-Reactive (kVArh)
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
-    + Optional    
-       
+    + Optional
+
 + `powerFactor` : Power factor.
     + Attribute Type: [Number](http://schema.org/Number)
     + Allowed values: A number between -1 and 1.
@@ -186,7 +188,7 @@ current phases, typically R, S, T.
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `cosPhi` : "Cosin of phi" parameter.
     + Attribute Type: [Number](http://schema.org/Number)
     + Allowed values: A number between -1 and 1.
@@ -194,11 +196,11 @@ current phases, typically R, S, T.
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-   
+
 + `intensity` : Electric intensity. The actual values will be conveyed
 by one subproperty per alternating current phase.  The name of each subproperty
 will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions.
-In Europe they are typically named as `R`, `S`, `T`. 
+In Europe they are typically named as `R`, `S`, `T`.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: Ampers (A)
     + Attribute metadata:
@@ -209,7 +211,7 @@ In Europe they are typically named as `R`, `S`, `T`.
 + `voltage` : Electric tension. The actual values will be conveyed
 by one subproperty alternating current phase.  The name of each subproperty
 will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions.
-In Europe they are typically named as `R`, `S`, `T`.  
+In Europe they are typically named as `R`, `S`, `T`.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Default unit: Volts (V)
     + Attribute metadata:
@@ -219,18 +221,18 @@ In Europe they are typically named as `R`, `S`, `T`.
 
 + `thdrVoltage` : Total harmonic distortion (R) of The name of each subproperty
 will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions.
-In Europe they are typically named as `R`, `S`, `T`. 
+In Europe they are typically named as `R`, `S`, `T`.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Allowed values: A number between 0 and 1
     + Optional
 
 + `thdrIntensity` : Total harmonic distortion (R) of intensity. The name of each subproperty
 will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions.
-In Europe they are typically named as `R`, `S`, `T`. 
+In Europe they are typically named as `R`, `S`, `T`.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Allowed values: A value between 0 and 1
     + Optional
-   
+
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`
@@ -276,4 +278,4 @@ mode (`options=keyValues`).
 
 + Should we create a `StreetlightControlCabinetModel` entity type?
 + Should we have the programming parameters as attribute of this entity? Advantage is that if programming is the same
-for all the controlled cicuits then there is no need to repeat the same parameters over multiple entities. 
+for all the controlled cicuits then there is no need to repeat the same parameters over multiple entities.

--- a/specs/StreetLighting/StreetlightGroup/doc/spec.md
+++ b/specs/StreetLighting/StreetlightGroup/doc/spec.md
@@ -1,24 +1,26 @@
 # Streetlight group
 
 An entity of type `StreetlightGroup` represents a group of streetlights. They might be controlled
-together by the same automated system (cabinet controller). 
+together by the same automated system (cabinet controller).
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : It must be equal to `StreetlightGroup`.
 
-+ `location` : Streetlight's group location represented by a GeoJSON (multi)geometry. 
++ `location` : Streetlight's group location represented by a GeoJSON (multi)geometry.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
     + Mandatory
-        
+
 + `areaServed` : Higher level area to which the streetlight group belongs to. It can be used to group per
 responsible, district, neighbourhood, etc.
     + Normative References: [https://schema.org/areaServed](https://schema.org/areaServed)
-    + Optional 
-    
+    + Optional
+
 + `powerState` : Streetlight group's power state.
     + Attribute type: [Text](http://schema.org/Text)
     + Attribute metadata:
@@ -26,11 +28,11 @@ responsible, district, neighbourhood, etc.
             + Type: [DateTime](http://schema.org/DateTime)
     + Allowed values: one Of (`on`, `off`, `low`, `bootingUp`)
     + Optional
-    
+
 + `refStreetlightCabinetController` : Streetlight group's cabinet controller
     + Attribute type : Reference to a [StreetlightCabinetController](../../StreetlightCabinetController/doc/spec.md) entity.
     + Optional
-    
+
 + `dateLastSwitchingOn` : Timestamp of the last switching on.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Attribute metadata:
@@ -45,28 +47,28 @@ responsible, district, neighbourhood, etc.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
 
-+ `switchingOnHours` : Switching on hours. It is used normally to set special schedules for certain dates. 
++ `switchingOnHours` : Switching on hours. It is used normally to set special schedules for certain dates.
     + Attribute Type: [StructuredValue](http://schema.org/StructuredValue)
     + Subproperties:
-        + `from` : Starting date (it can be yearless). 
+        + `from` : Starting date (it can be yearless).
             + Type: [Date](https://schema.org/Date)
         + `to` : Ending date (it can be yearless)
             + Type: [Date](https://schema.org/Date)
-        + `hours` : Hours. 
+        + `hours` : Hours.
             + Normative References: Value must be compliant with [https://schema.org/openingHours](https://schema.org/openingHours)
     + Attribute metadata:
         + `timestamp` : Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-        
-+ `switchingMode` : Switching mode. 
+
++ `switchingMode` : Switching mode.
     + Attribute Type: List of [Text](http://schema.org/Text)
     + Allowed values: (`night-ON`, `night-OFF`, `night-LOW`, `always-ON`, `day-ON`, `day-OFF`, `day-LOW`)
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-    
+
 + `illuminanceLevel` : Relative illuminance level setting for the group.
     + Attribute Type: [Number](http://schema.org/Number)
     + Allowed values: A number between 0 and 1.
@@ -74,19 +76,19 @@ responsible, district, neighbourhood, etc.
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
     + Optional
-        
+
 + `activeProgramId` : Identifier of the active program for this streetlight group.
     + Attribute type: [Text](https://schema.org/Text)
     + Attribute metadata:
         + `timestamp`: Timestamp when the last update of the attribute happened.
             + Type: [DateTime](http://schema.org/DateTime)
-    + Optional 
-    
+    + Optional
+
 + `dateModified` : Timestamp of the last update made to this entity.
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Read-Only. Automatically generated.
-        
-+ `description` : Description about the streetlight group. 
+
++ `description` : Description about the streetlight group.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
 
@@ -94,9 +96,9 @@ responsible, district, neighbourhood, etc.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Optional
 
-+ `refStreetlight` : List of streetlight entities belonging to this group. 
++ `refStreetlight` : List of streetlight entities belonging to this group.
     + Attribute type: List of references to entities fo type [Streetlight](../../Streetlight/doc/spec.md)
-    + Allowed values: There must topographical integrity between the location of the group and of the individual streetlights.  
+    + Allowed values: There must topographical integrity between the location of the group and of the individual streetlights.
     + Optional
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
@@ -115,7 +117,7 @@ mode (`options=keyValues`).
           [ [102.0, 2.0], [103.0, 3.0] ]
         ]
       },
-      "powerStatus": "on", 
+      "powerStatus": "on",
       "areaServed": "Calle Comercial Centro",
       "circuitId": "C-456-A467",
       "dateLastSwitchingOn":  "2016-07-07T19:59:06.618Z",
@@ -136,4 +138,4 @@ mode (`options=keyValues`).
 
 ## Open Issues
 
-+ Do we really need metering attributes on this entity? Is metering only going to be done at Cabinet level? 
++ Do we really need metering attributes on this entity? Is metering only going to be done at Cabinet level?

--- a/specs/StreetLighting/StreetlightModel/doc/spec.md
+++ b/specs/StreetLighting/StreetlightModel/doc/spec.md
@@ -1,11 +1,13 @@
 # Streetlight Model
 
 It represents a model of streetlight composed by a specific supporting structure model,
-a lantern model and a lamp model. A streetlight instance will be based on a certain streetlight model. 
+a lantern model and a lamp model. A streetlight instance will be based on a certain streetlight model.
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : It must be equal to `StreetlightModel`.
 
@@ -13,7 +15,7 @@ a lantern model and a lamp model. A streetlight instance will be based on a cert
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
 
-+ `alternateName` : Alternate name given to the streetlight model. 
++ `alternateName` : Alternate name given to the streetlight model.
     + Normative References: [https://schema.org/alternateName](https://schema.org/alternateName)
     + Optional
 
@@ -25,11 +27,11 @@ a lantern model and a lamp model. A streetlight instance will be based on a cert
     + Attribute type: List of [Number](https://schema.org/Number).
     + Default unit: Watts (W)
     + Optional
-    
+
 + `minPowerConsumption` : Minimum power consumption supported by the lantern.
     + Attribute type: List of [Number](https://schema.org/Number).
     + Default unit: Watts (W)
-    + Optional    
+    + Optional
 
 + `columnBrandName` : Name of the column's brand.
     + Attribute type: [Text](https://schema.org/Text)
@@ -45,12 +47,12 @@ a lantern model and a lamp model. A streetlight instance will be based on a cert
     + Attribute type: [Text](https://schema.org/Text)
     + See also: [https://schema.org/model](https://schema.org/manufacturer)
     + Optional
-    
-+ `columnMadeOf` : Material column is made of. 
+
++ `columnMadeOf` : Material column is made of.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: one Of (`steel`, `aluminium` , `wood`, `other`)
     + Optional
-    
+
 + `columnColor` : Column's painting color.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed Values:
@@ -73,12 +75,12 @@ a lantern model and a lamp model. A streetlight instance will be based on a cert
     + Attribute type: [Text](https://schema.org/Text)
     + See also: [https://schema.org/model](https://schema.org/manufacturer)
     + Optional
-    
+
 + `lanternWeight` : Lantern's weight.
     + Attribute type: [Number](https://schema.org/Number).
     + Default Unit: Kilograms (kg)
     + See also: [https://schema.org/weight](https://schema.org/weight)
-    + Optional    
+    + Optional
 
 + `lampModelName` : Name of the lamp's model.
     + Attribute type: [Text](https://schema.org/Text)
@@ -94,44 +96,44 @@ a lantern model and a lamp model. A streetlight instance will be based on a cert
     + Attribute type: [Text](https://schema.org/Text)
     + See also: [https://schema.org/model](https://schema.org/manufacturer)
     + Optional
-    
+
 + `lampWeight` : Lamp's weight.
     + Attribute type: [Number](https://schema.org/Number).
     + Default Unit: Kilograms (kg)
     + See also: [https://schema.org/weight](https://schema.org/weight)
     + Optional
-    
+
 + `workingLife` : The estimated number of hours working (the lamp) without failure.
     + Attribute type: [Number](http://schema.org/Number)
     + Default unit: hours
     + Optional
-    
+
 + `lampTechnology` : Technology used by the lamp.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: one Of (`LED`, `LPS`, `HPS`)
-        + Or any other value not covered by the above list and meaningful to the application. 
-    + Optional 
+        + Or any other value not covered by the above list and meaningful to the application.
+    + Optional
 
-+ `colorTemperature` : *Correlated* color temperature of the lamp. 
++ `colorTemperature` : *Correlated* color temperature of the lamp.
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: Kelvin degrees (K)
     + Optional
 
 + `colorRenderingIndex` : Color rendering index of the lamp.
     + Attribute type: [Number](https://schema.org/Number)
-    + Optional 
+    + Optional
 
 + `luminousFlux` :  Maximum light output which can be provided by the lamp.
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: Lumens (lm)
-    + Optional  
+    + Optional
 
 + `powerConsumption` : (Nominal) power consumption made by the lamp.
     + Attribute type: List of [Number](https://schema.org/Number).
     + Default unit: Watts (W)
     + Optional
 
-+ `compliantWith` : A list of standards to which this streetlight model is compliant with. 
++ `compliantWith` : A list of standards to which this streetlight model is compliant with.
     + AttributeType: List of [Text](https://schema.org/Text).
     + Optional
 
@@ -157,7 +159,7 @@ mode (`options=keyValues`).
       "type": "StreetlightModel",
       "name": "Tubular Numana 6M - ASR42CG - Son-T 100",
       "columnModelName": "01 TUBULAR P/T 6M NUMANA",
-      "columnColor": "green", 
+      "columnColor": "green",
       "lanternModelName": "ASR42CG",
       "lanternManufacturerName": "Indal WRTL",
       "lampModelName": "SON-T",

--- a/specs/Transportation/CrowdFlowObserved/doc/spec.md
+++ b/specs/Transportation/CrowdFlowObserved/doc/spec.md
@@ -6,25 +6,27 @@ An observation related to the movement of people at a certain place and time.
 
 ## Data Model
 
-+ `id`: Entity id. 
-    + It shall be `urn:ngsi-ld:CrowdFlowObserved:<identifier>` being `identifier` a unique identifier. 
+The data model is defined as shown below:
 
-+ `type`: Entity type. 
++ `id`: Entity id.
+    + It shall be `urn:ngsi-ld:CrowdFlowObserved:<identifier>` being `identifier` a unique identifier.
+
++ `type`: Entity type.
     + It shall be equal to `CrowdFlowObserved`.
-    
+
 + `dateCreated` : Entity's creation timestamp. (`createdAt` in NGSI-LD)
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity. (`modifiedAt` in NGSI-LD)
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `source` : A sequence of characters giving the original source of the Entity data as a URL.
     + Attribute type: [URL](https://schema.org/URL)
     + Mandatory
 
-+ `location` : Location of this crowd flow observation represented by a GeoJSON geometry. 
++ `location` : Location of this crowd flow observation represented by a GeoJSON geometry.
     + Attribute type: `geo:json`. (`GeoProperty`)
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `refRoadSegment` or `address` are not present.
@@ -32,25 +34,25 @@ An observation related to the movement of people at a certain place and time.
 + `address` : Civic address of this crowd flow observation.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Mandatory if `location` or `refRoadSegment` are not present.
-    
+
 + `refRoadSegment` : Concerned road segment on which the observation has been mede.
     + Attribute type: Relationship. Reference to an entity of type [RoadSegment](../../RoadSegment/doc/spec.md).
-    + Mandatory if `location` or `address` are not present. 
+    + Mandatory if `location` or `address` are not present.
 
 + `dateObserved` : The date and time of this observation in ISO8601 UTC format.
 It can be represented by an specific time instant or by an ISO8601 interval. As a workaround for
-the lack of support of Orion Context Broker for datetime intervals, it can be used two separate attributes: `dateObservedFrom`, `dateObservedTo`. 
-    + Attribute type: [DateTime](https://schema.org/DateTime) or an ISO8601 interval represented as [Text](https://schema.org/Text). 
+the lack of support of Orion Context Broker for datetime intervals, it can be used two separate attributes: `dateObservedFrom`, `dateObservedTo`.
+    + Attribute type: [DateTime](https://schema.org/DateTime) or an ISO8601 interval represented as [Text](https://schema.org/Text).
     + Mandatory
-        
-+ `dateObservedFrom` : Observation period start date and time. See `dateObserved`. 
-    + Attribute type: TemporalProperty. [DateTime](https://schema.org/DateTime). 
+
++ `dateObservedFrom` : Observation period start date and time. See `dateObserved`.
+    + Attribute type: TemporalProperty. [DateTime](https://schema.org/DateTime).
     + Optional
-    
-+ `dateObservedTo` : Observation period end date and time. See `dateObserved`. 
-    + Attribute type: TemporalProperty. [DateTime](https://schema.org/DateTime). 
+
++ `dateObservedTo` : Observation period end date and time. See `dateObserved`.
+    + Attribute type: TemporalProperty. [DateTime](https://schema.org/DateTime).
     + Optional
-    
+
 + `name` : Name given to this observation.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Optional
@@ -58,9 +60,9 @@ the lack of support of Orion Context Broker for datetime intervals, it can be us
 + `description` : Description of this observation.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `peopleCount` : Total number of people detected during this observation period.
-    + Attribute type: [Number](https://schema.org/Number). Positive integer. 
+    + Attribute type: [Number](https://schema.org/Number). Positive integer.
     + Optional
 
 + `occupancy` : Fraction of the observation time where a person has been occupying the observed walkway.
@@ -71,19 +73,19 @@ the lack of support of Orion Context Broker for datetime intervals, it can be us
     + Attribute type: Property. [Number](https://schema.org/Number)
     + Default unit: Kilometer per hour (Km/h).
     + Optional
-    
-+ `congested` : Flags whether there was a crowd congestion during the observation period in the referred walkway. The absence of this attribute means no crowd congestion.  
+
++ `congested` : Flags whether there was a crowd congestion during the observation period in the referred walkway. The absence of this attribute means no crowd congestion.
     + Attribute type: Property. [Boolean](https://schema.org/Boolean)
     + Optional
-    
+
 + `averageHeadwayTime` : Average headway time. Headway time is the time elapsed between two consecutive persons.
     + Attribute type: Property. [Number](https://schema.org/Number)
     + Default unit: second (s)
     + Optional
-    
+
 + `direction` : Usual direction of travel in the walkway referred by this observation with respect to the city center.
     + Attribute type: Property. [Text](https://schema.org/Text)
-    + Allowed values: (`inbound`, `outbound`). 
+    + Allowed values: (`inbound`, `outbound`).
     + Optional
 
 
@@ -91,48 +93,48 @@ the lack of support of Orion Context Broker for datetime intervals, it can be us
 
 ```json
 {
-    "id": "urn:ngsi-ld:CrowdFlowObserved:Valladolid_1", 
-    "type": "CrowdFlowObserved", 
+    "id": "urn:ngsi-ld:CrowdFlowObserved:Valladolid_1",
+    "type": "CrowdFlowObserved",
     "dateObserved": {
         "value": "2018-08-07T11:10:00/2018-08-07T11:15:00"
-    }, 
+    },
     "direction": {
         "value": "inbound"
-    }, 
+    },
     "dateObservedFrom": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2018-08-07T11:10:00Z"
-    }, 
+    },
     "peopleCount": {
         "value": 100
-    }, 
+    },
     "averageHeadwayTime": {
         "value": 5
-    }, 
+    },
     "dateObservedTo": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2018-08-07T11:15:00Z"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "LineString", 
+            "type": "LineString",
             "coordinates": [
                 [
-                    -4.73735395519672, 
+                    -4.73735395519672,
                     41.6538181849672
-                ], 
+                ],
                 [
-                    -4.73414858659993, 
+                    -4.73414858659993,
                     41.6600594193478
-                ], 
+                ],
                 [
-                    -4.73447575302641, 
+                    -4.73447575302641,
                     41.659585195093
                 ]
             ]
         }
-    }, 
+    },
     "congested": {
         "value": false
     }

--- a/specs/Transportation/Road/doc/spec.md
+++ b/specs/Transportation/Road/doc/spec.md
@@ -5,7 +5,7 @@
 This entity contains a harmonised geographic and contextual description of a road.
 Roads are made up of one or more [RoadSegment](../../RoadSegment/doc/spec.md) entities.
 Road segments are usually used to model the different carriageways of highways, for instance.
-The presence of dedicated bicycle lanes should be modelled using road segments as well. 
+The presence of dedicated bicycle lanes should be modelled using road segments as well.
 Road segments also play an important role when modelling roads with heterogeneous segments, for instance
 segments on which speed limits are different.
 
@@ -15,7 +15,9 @@ This data model has been developed in cooperation with mobile operators and the 
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `Road`.
 
@@ -26,38 +28,38 @@ This data model has been developed in cooperation with mobile operators and the 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-        
+
 + `name` : Name given to this road, for instance `M-30`.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
-    
+
 + `alternateName` : An alias for this road.
     + Normative References: [https://schema.org/alternateName](https://schema.org/alternateName)
     + Optional
-    
-+ `description` : Description or long name given to this road. 
+
++ `description` : Description or long name given to this road.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `roadClass` : The classification of this road.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: Those described by [http://wiki.openstreetmap.org/wiki/Key:highway](OpenStreetMap).
     + Mandatory
 
-+ `refRoadSegment` : Road segments which define this road. 
++ `refRoadSegment` : Road segments which define this road.
     + Attribute type: List of references to entities of type [RoadSegment](../../RoadSegment/doc/spec.md).
-    + MAndatory 
-    
+    + MAndatory
+
 + `length` : Total length of this road in kilometers.
     + Attribute type: [Number](https://schema.org/Number)
     + See also [https://schema.org/length](https://schema.org/length)
     + Default unit: Kilometer (Km)
     + Optional
-    
+
 + `responsible` : Responsible for the raod i.e. the organism or company in charge of its maintenance.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-    
+
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`
 mode (`options=keyValues`).

--- a/specs/Transportation/RoadSegment/doc/spec.md
+++ b/specs/Transportation/RoadSegment/doc/spec.md
@@ -20,7 +20,9 @@ This data model has been developed in cooperation with mobile operators and the 
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `RoadSegment`.
 
@@ -31,29 +33,29 @@ This data model has been developed in cooperation with mobile operators and the 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-    
+
 + `source` : The source of this data.
     + Attribute type: [URL](https://schema.org/URL)
     + Optional
-    
+
 + `name` : Name given to this road segment.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
-    
+
 + `alternateName` : An alias for this road segment.
     + Normative References: [https://schema.org/alternateName](https://schema.org/alternateName)
     + Optional
-    
-+ `refRoad` : Road to which this road segment belongs to.   
+
++ `refRoad` : Road to which this road segment belongs to.
     + Attribute type: A reference to an entity of type [Road](../../Road/doc/spec.md).
     + Mandatory
-    
+
 + `location` : A GeoJSON (multi)line string which defines this road segment.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
-    
-+ `startPoint` : The start point of this road segment encoded as a GeoJSON point. 
+
++ `startPoint` : The start point of this road segment encoded as a GeoJSON point.
     + Attribute type: `geo:json`
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
@@ -62,7 +64,7 @@ This data model has been developed in cooperation with mobile operators and the 
     + Attribute type: `geo:json`
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
-    
+
 + `startKilometer` : The kilometer number (measured from the road's start point) where this road segmnent starts.
     + Attribute type: [Number](https://schema.org/Number)
     + Optional
@@ -80,26 +82,26 @@ This data model has been developed in cooperation with mobile operators and the 
            `motorcycle`, `motorcycleWithSideCar`,
            `motorscooter`, `tanker`, `trailer`, `van`, `anyVehicle`)
     + Mandatory
-    
+
 + `totalLaneNumber` : Total number of lanes offered by this road segment.
     + Attribute type: [Number](https://schema.org/Number). Integer greater than 0.
     + Mandatory
-    
+
 + `length` : Total length of this road segment in kilometers.
     + Attribute type: [Number](https://schema.org/Number)
     + See also [https://schema.org/length](https://schema.org/length)
     + Default unit: Kilometer (Km)
     + Optional
-     
+
 + `maximumAllowedSpeed` : Maximum allowed speed while transiting this road segment. More restrictive limits
 might be applied to specific vehicle types (trucks, caravans, etc.).
     + Attribute type: [Number](https://schema.org/Number)
-    + Default unit: Kilometer per hour (Km/h). 
+    + Default unit: Kilometer per hour (Km/h).
     + Optional
-    
+
 + `minimumAllowedSpeed` : Minimum allowed speed while transiting this road segment.
     + Attribute type: [Number](https://schema.org/Number)
-    + Default unit: Kilometer per hour (Km/h). 
+    + Default unit: Kilometer per hour (Km/h).
     + Optional
 
 + `maximumAllowedHeight` : Maximum allowed height for vehicles transiting this road segment.
@@ -107,19 +109,19 @@ might be applied to specific vehicle types (trucks, caravans, etc.).
     + See also: [https://schema.org/height](https://schema.org/height)
     + Default unit: Meter (m)
     + Optional
-    
+
 + `maximumAllowedWeight` : Maximum allowed weight for vehicles transiting this road segment.
     + Attribute type: [Number](https://schema.org/Number)
     + See also: [https://schema.org/weight](https://schema.org/weight)
     + Default unit: Kilogram (Kg)
     + Optional
 
-+ `width` : Road's segmwent width. 
++ `width` : Road's segmwent width.
     + Normative References: [https://schema.org/width](https://schema.org/width)
     + Default unit: Meter (m)
     + Optional
-    
-+ `laneUsage` : This attribute can be used to convey specific parameters describing each lane. 
+
++ `laneUsage` : This attribute can be used to convey specific parameters describing each lane.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed values: It must contain a string per road segment lane. The element 0 of the array must
     contain the information of lane 1, and so on. Format of the referred string must be:
@@ -128,9 +130,9 @@ might be applied to specific vehicle types (trucks, caravans, etc.).
         + `forward`. The lane is currently used in the `forwards` direction.
         + `backward`. The lane is currently used in the `backwards` direction.
     The only mandatory parameter is `lane_direction`. If not specified, the rest of parameters
-    can be assumed to be equal to those specified at entity level. 
+    can be assumed to be equal to those specified at entity level.
     + Optional
- 
+
 + `category` : Allows to convey extra characteristics of a road segment.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed values:
@@ -140,11 +142,11 @@ might be applied to specific vehicle types (trucks, caravans, etc.).
         + `toll` : Flags whether the road segment is under toll fees.
         + `link` : Flags whether this road segment is an auxiliary link segment for exiting or entering a road. See
         [https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link)
-        + Any other value meaningful to an application. 
+        + Any other value meaningful to an application.
     + Optional
 
 The properties `laneUsage` and those which convey the maximum allowed parameters can be dynamic, for instance,
-a lane direction can be temporarily changed to improve traffic conditions. 
+a lane direction can be temporarily changed to improve traffic conditions.
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`
@@ -153,7 +155,7 @@ mode (`options=keyValues`).
 ## Examples of use
 
 
-Please note that this road segment's line string has been simplified only four points just to make the example shorter.  
+Please note that this road segment's line string has been simplified only four points just to make the example shorter.
 
 ```
 {
@@ -201,6 +203,6 @@ Please note that this road segment's line string has been simplified only four p
 
 ## Use it with a real service
 
-T.B.D. 
+T.B.D.
 
 ## Open issues

--- a/specs/Transportation/TrafficFlowObserved/doc/spec.md
+++ b/specs/Transportation/TrafficFlowObserved/doc/spec.md
@@ -7,11 +7,13 @@ the Automotive and Smart City vertical segments and related IoT applications.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type` : Entity type. It must be equal to `TrafficFlowObserved`.
 
-+ `location` : Location of this traffic flow observation represented by a GeoJSON geometry. 
++ `location` : Location of this traffic flow observation represented by a GeoJSON geometry.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `refRoadSegment` is not present.
@@ -19,36 +21,36 @@ the Automotive and Smart City vertical segments and related IoT applications.
 + `address` : Civic address of this traffic flow observation.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Optional
-    
+
 + `refRoadSegment` : Concerned road segment on which the observation has been mede.
     + Attribute type: Reference to an entity of type [RoadSegment](../../RoadSegment/doc/spec.md).
-    + Mandatory if `location` is not present. 
+    + Mandatory if `location` is not present.
 
 + `dateModified` : Last update timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-        
+
 + `laneId` : Lane identifier.
     + Attribute type: [Number](https://schema.org/Number)
     + Allowed values: Positive integer starting with `1`. Lane identification is done using the conventions
     defined by [RoadSegment](../../RoadSegment/doc/spec.md) which are based on
     [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Forward_%26_backward,_left_%26_right).
     + Mandatory
-    
+
 + `dateObserved` : The date and time of this observation in ISO8601 UTC format.
 It can be represented by an specific time instant or by an ISO8601 interval. As a workaround for
-the lack of support of Orion Context Broker for datetime intervals, it can be used two separate attributes: `dateObservedFrom`, `dateObservedTo`. 
-    + Attribute type: [DateTime](https://schema.org/DateTime) or an ISO8601 interval represented as [Text](https://schema.org/Text). 
+the lack of support of Orion Context Broker for datetime intervals, it can be used two separate attributes: `dateObservedFrom`, `dateObservedTo`.
+    + Attribute type: [DateTime](https://schema.org/DateTime) or an ISO8601 interval represented as [Text](https://schema.org/Text).
     + Mandatory
-        
-+ `dateObservedFrom` : Observation period start date and time. See `dateObserved`. 
-    + Attribute type: [DateTime](https://schema.org/DateTime). 
+
++ `dateObservedFrom` : Observation period start date and time. See `dateObserved`.
+    + Attribute type: [DateTime](https://schema.org/DateTime).
     + Optional
-    
-+ `dateObservedTo` : Observation period end date and time. See `dateObserved`. 
-    + Attribute type: [DateTime](https://schema.org/DateTime). 
+
++ `dateObservedTo` : Observation period end date and time. See `dateObserved`.
+    + Attribute type: [DateTime](https://schema.org/DateTime).
     + Optional
-    
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
@@ -60,9 +62,9 @@ the lack of support of Orion Context Broker for datetime intervals, it can be us
 + `description` : Description of this observation.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `intensity` : Total number of vehicles detected during this observation period.
-    + Attribute type: [Number](https://schema.org/Number). Positive integer. 
+    + Attribute type: [Number](https://schema.org/Number). Positive integer.
     + Optional
 
 + `occupancy` : Fraction of the observation time where a vehicle has been occupying the observed laned.
@@ -73,40 +75,40 @@ the lack of support of Orion Context Broker for datetime intervals, it can be us
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: Kilometer per hour (Km/h).
     + Optional
-    
+
 + `averageVehicleLength` : Average length of the vehicles transiting during the observation period.
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: meter (m)
     + Optional
-    
+
 + `congested` : Flags whether there was a traffic congestion during the observation period in the referred lane.
-The absence of this attribute means no traffic congestion. 
+The absence of this attribute means no traffic congestion.
     + Attribute type: [Boolean](https://schema.org/Boolean)
     + Optional
-    
+
 + `averageHeadwayTime` : Average headway time. Headaway time is the time ellapsed between two consecutive vehicles.
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: second (s)
     + Optional
-    
+
 + `averageGapDistance` : Average gap distance between consecutive vehicles.
     + Attribute type: [Number](https://schema.org/Number)
     + Default unit: meter (m)
     + Optional
-    
+
 + `laneDirection` : Usual direction of travel in the lane referred by this observation. This attribute
 is useful when the observation is not referencing any road segment, allowing to know the direction of travel
-of the traffic flow observed. 
+of the traffic flow observed.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: (`forward`, `backward`). See [RoadSegment.laneUsage](../../RoadSegment/doc/spec.md)
-    for a description of the semantics of these values. 
+    for a description of the semantics of these values.
     + Optional
-    
+
 + `reversedLane`: Flags whether traffic in the lane was reversed during the observation period. The absence of this
-attribute means no lane reversion. 
+attribute means no lane reversion.
     + Attribute type: [Boolean](https://schema.org/Boolean)
     + Optional
-    
+
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`
 mode (`options=keyValues`).
@@ -116,67 +118,67 @@ mode (`options=keyValues`).
 ```json
 {
     "id": "TrafficFlowObserved-Valladolid-osm-60821110",
-    "type": "TrafficFlowObserved", 
+    "type": "TrafficFlowObserved",
     "dateObserved": {
         "value": "2016-12-07T11:10:00/2016-12-07T11:15:00"
-    }, 
+    },
     "laneDirection": {
         "value": "forward"
-    }, 
+    },
     "dateObservedFrom": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-12-07T11:10:00"
-    }, 
+    },
     "averageVehicleLength": {
         "value": 9.87
-    }, 
+    },
     "averageHeadwayTime": {
         "value": 0.5
-    }, 
+    },
     "occupancy": {
         "value": 0.76
-    }, 
+    },
     "reversedLane": {
         "value": false
-    }, 
+    },
     "dateObservedTo": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-12-07T11:15:00"
-    }, 
+    },
     "intensity": {
         "value": 197
-    }, 
+    },
     "laneId": {
         "value": 1
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "LineString", 
+            "type": "LineString",
             "coordinates": [
                 [
-                    -4.73735395519672, 
+                    -4.73735395519672,
                     41.6538181849672
-                ], 
+                ],
                 [
-                    -4.73414858659993, 
+                    -4.73414858659993,
                     41.6600594193478
-                ], 
+                ],
                 [
-                    -4.73447575302641, 
+                    -4.73447575302641,
                     41.659585195093
                 ]
             ]
         }
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "Valladolid", 
-            "addressCountry": "ES", 
+            "addressLocality": "Valladolid",
+            "addressCountry": "ES",
             "streetAddress": "Avenida de Salamanca"
         }
-    }, 
+    },
     "averageVehicleSpeed": {
         "value": 52.6
     }
@@ -219,7 +221,7 @@ mode (`options=keyValues`).
        "averageVehicleLength": 9.87,
        "reversedLane": false,
        "laneDirection": "forward"
-    }    
+    }
 ```
 
 

--- a/specs/Transportation/Vehicle/Vehicle/doc/spec.md
+++ b/specs/Transportation/Vehicle/Vehicle/doc/spec.md
@@ -6,18 +6,20 @@ A vehicle.
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : Entity type. It must be equal to `Vehicle`.
 
-+ `name` : Name given to this vehicle. 
++ `name` : Name given to this vehicle.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Optional
 
-+ `description` : Vehicle description. 
++ `description` : Vehicle description.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `vehicleType` : Type of vehicle from the point of view of its structural characteristics.
 This is different than the vehicle category (see below).
     + Attribute type: [Text](https://schema.org/Text)
@@ -28,7 +30,7 @@ This is different than the vehicle category (see below).
            `motorcycle`, `motorcycleWithSideCar`, `motorscooter`, `trailer`, `van`, `caravan`, `constructionOrMaintenanceVehicle`)
         + (`trolley`, `binTrolley`, `sweepingMachine`, `cleaningTrolley`)
     + Mandatory
-    
+
 + `category` : Vehicle category(ies) from an external point of view.
 This is different than the vehicle type (car, lorry, etc.) represented by the `vehicleType` property.
     + Attribute type: List of [Text](https:/schema.org/Text)
@@ -40,7 +42,7 @@ This is different than the vehicle type (car, lorry, etc.) represented by the `v
     + Mandatory
 
 + `location` : Vehicle's last known location represented by a GeoJSON Point. Such point may contain the vehicle's
-*altitude* as the third component of the `coordinates` array. 
+*altitude* as the third component of the `coordinates` array.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Attribute metadata:
@@ -48,8 +50,8 @@ This is different than the vehicle type (car, lorry, etc.) represented by the `v
         This value can also appear as a FIWARE [TimeInstant](https://github.com/telefonicaid/iotagent-node-lib/blob/develop/README.md#TimeInstant)
             + Type: [DateTime](http://schema.org/DateTime) or `ISO8601` (legacy).
             + Mandatory
-    + Mandatory only if `category` contains `tracked`. 
-    
+    + Mandatory only if `category` contains `tracked`.
+
 + `previousLocation` : Vehicle's previous location represented by a GeoJSON Point. Such point may contain the previous vehicle's
 *altitude* as the third component of the`coordinates` array.
     + Attribute type: `geo:json`.
@@ -59,9 +61,9 @@ This is different than the vehicle type (car, lorry, etc.) represented by the `v
             + Type: [DateTime](http://schema.org/DateTime)
             + Mandatory
     + Optional
-    
+
 + `speed` : Denotes the magnitude of the horizontal component of the vehicle's current velocity and is specified in Kilometers per Hour.
-If provided, the value of the speed attribute must be a non-negative real number. `null` *MAY* be used if `speed` is transiently unknown for some reason.    
+If provided, the value of the speed attribute must be a non-negative real number. `null` *MAY* be used if `speed` is transiently unknown for some reason.
     + Attribute type: [Number](https:/schema.org/Number)
     + Default unit: Kilometers per hour
     + Attribute metadata:
@@ -70,10 +72,10 @@ If provided, the value of the speed attribute must be a non-negative real number
             + Type: [DateTime](http://schema.org/DateTime) or `ISO8601` (legacy).
             + Mandatory
     + Mandatory only if `category` contains `tracked`.
-    
+
 + `heading` : Denotes the direction of travel of the vehicle and is specified in decimal degrees,
 where 0° ≤ `heading` < 360°, counting clockwise relative to the true north.  If the vehicle is stationary (i.e. the value of the `speed` attribute is `0`),
-then the value of the heading attribute must be equal to `null`. `null` *MAY* be used if `heading` is transiently unknown for some reason.   
+then the value of the heading attribute must be equal to `null`. `null` *MAY* be used if `heading` is transiently unknown for some reason.
     + Attribute type: [Number](https://schema.org)
     + Attribute metadata:
         + `timestamp` :  Timestamp which captures when the vehicle was heading towards such direction.
@@ -96,7 +98,7 @@ then the value of the heading attribute must be equal to `null`. `null` *MAY* be
 to identify individual motor vehicles.
     + Normative References: [https://schema.org/vehicleIdentificationNumber](https://schema.org/vehicleIdentificationNumber)
     + Mandatory if neither `vehiclePlateIdentifier` nor `fleetVehicleId` is defined.
-    
+
 + `vehiclePlateIdentifier` : An identifier or code displayed on a vehicle registration plate attached to the vehicle used for official identification purposes.
 The registration identifier is numeric or alphanumeric and is unique within the issuing authority's region.
     + Normative References: DATEX II `vehicleRegistrationPlateIdentifier`
@@ -110,7 +112,7 @@ The registration identifier is numeric or alphanumeric and is unique within the 
 + `dateVehicleFirstRegistered` : The date of the first registration of the vehicle with the respective public authorities.
     + Normative References: [https://schema.org/dateVehicleFirstRegistered](https://schema.org/dateVehicleFirstRegistered)
     + Optional
-    
+
 + `dateFirstUsed` : Timestamp which denotes when the vehicle was first used.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Optional
@@ -140,7 +142,7 @@ The registration identifier is numeric or alphanumeric and is unique within the 
     + Attribute Type: [https://schema.org/Person](https://schema.org/Person) or
     [https://schema.org/Organization](https://schema.org/Organization)
     + Optional
-    
+
 + `feature` : Feature(s) incorporated by the vehicle.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed values: (`gps`, `airbag`, `overspeed`, `abs`, `wifi`, `backCamera`, `proximitySensor`,
@@ -170,14 +172,14 @@ driving school, or as a taxi. The legislation in many countries requires this in
 responsible, district, neighbourhood, etc.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-    
+
 + `serviceStatus` : Vehicle status (from the point of view of the service provided, so it could not apply to private vehicles).
     + Allowed values:
         + `parked`  : Vehicle is parked and not providing any service at the moment.
         + `onRoute` : Vehicle is performing a mission. A comma-separated modifier(s) can be added to indicate what mission is currently delivering the vehicle.
         For instance `"onRoute,garbageCollection"` can be used to denote that the vehicle is on route and in a garbage collection mission.
         + `broken` : Vehicle is suffering a temporary breakdown.
-        + `outOfService` : Vehicle is on the road but not performing any mission, probably going to its parking area. 
+        + `outOfService` : Vehicle is on the road but not performing any mission, probably going to its parking area.
     + Attribute type: [Text](https://schema.org/Text)
     + Attribute metadata:
         + `timestamp` : Timestamp which reflects when the referred service status was captured.
@@ -192,7 +194,7 @@ responsible, district, neighbourhood, etc.
 + `dateCreated` : Creation timestamp of this entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-    
+
 **Note**: JSON Schemas only capture the NGSI simplified representation, this means that to test the JSON schema examples with
 a [FIWARE NGSI version 2](http://fiware.github.io/specifications/ngsiv2/stable) API implementation, you need to use the `keyValues`
 mode (`options=keyValues`).
@@ -202,31 +204,31 @@ mode (`options=keyValues`).
 ```json
 {
     "id": "vehicle:WasteManagement:1",
-    "type": "Vehicle", 
+    "type": "Vehicle",
     "category": {
         "value": [
             "municipalServices"
         ]
-    }, 
+    },
     "vehicleType": {
         "value": "lorry"
-    }, 
+    },
     "name": {
         "value": "C Recogida 1"
-    }, 
+    },
     "vehiclePlateIdentifier": {
         "value": "3456ABC"
-    }, 
+    },
     "refVehicleModel": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "vehiclemodel:econic"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
+            "type": "Point",
             "coordinates": [
-                -3.164485591715449, 
+                -3.164485591715449,
                 40.62785133667262
             ]
         },
@@ -236,16 +238,16 @@ mode (`options=keyValues`).
                 "value": "2018-09-27T12:00:00"
             }
         }
-    }, 
+    },
     "areaServed": {
         "value": "Centro"
-    }, 
+    },
     "serviceStatus": {
         "value": "onRoute"
-    }, 
+    },
     "cargoWeight": {
         "value": 314
-    }, 
+    },
     "speed": {
         "value": 50,
         "metadata": {
@@ -254,10 +256,10 @@ mode (`options=keyValues`).
                 "value": "2018-09-27T12:00:00"
             }
         }
-    },  
+    },
     "serviceProvided": {
         "value": [
-            "garbageCollection", 
+            "garbageCollection",
             "wasteContainerCleaning"
         ]
     }
@@ -284,7 +286,7 @@ mode (`options=keyValues`).
       "refVehicleModel": "vehiclemodel:econic",
       "vehiclePlateIdentifier": "3456ABC"
 }
-    
+
 ## Test it with a real service
 
 T.B.D.

--- a/specs/Transportation/Vehicle/VehicleModel/doc/spec.md
+++ b/specs/Transportation/Vehicle/VehicleModel/doc/spec.md
@@ -2,22 +2,24 @@
 
 ## Description
 
-This entity models a particular vehicle model, including all properties which are common to multiple vehicle instances belonging to such model. 
+This entity models a particular vehicle model, including all properties which are common to multiple vehicle instances belonging to such model.
 
 ## Data Model
 
-+ `id` : Entity's unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Entity's unique identifier.
 
 + `type` : Entity type. It must be equal to `VehicleModel`.
 
-+ `name` : Name given to this vehicle model. 
++ `name` : Name given to this vehicle model.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
 
-+ `description` : Vehicle model description. 
++ `description` : Vehicle model description.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `vehicleType` : Type of vehicle from the point of view of its structural characteristics.
     + See definition at [Vehicle](../../Vehicle/doc/spec.md).
     + Mandatory
@@ -46,7 +48,7 @@ This entity models a particular vehicle model, including all properties which ar
     + Default Unit: Liters
     + Optional
     + Note: If only a single value is provided (type Number) it will refer to the maximum volume.
-    
+
 + `fuelType` : The type of fuel suitable for the engine or engines of the vehicle.
     + Normative References: [https://schema.org/fuelType](https://schema.org/fuelType)
     + Allowed values: one Of (`gasoline`, `petrol(unleaded)`, `petrol(leaded)`, `petrol`, `diesel`, `electric`,
@@ -56,7 +58,7 @@ This entity models a particular vehicle model, including all properties which ar
 + `fuelConsumption` : The amount of fuel consumed for traveling a particular distance or temporal
 duration with the given vehicle (e.g. liters per 100 km).
     + Normative References: [https://schema.org/fuelConsumption](https://schema.org/fuelConsumption)
-    + Default unit: liters per 100 kilometer. 
+    + Default unit: liters per 100 kilometer.
     + Optional
 
 + `height` : Vehicle's height.
@@ -79,11 +81,11 @@ duration with the given vehicle (e.g. liters per 100 km).
     + Normative References: [https://schema.org/vehicleEngine](https://schema.org/vehicleEngine)
     + Optional
     + Note: This property could be at vehicle level as well.
-    
+
 + `url` : URL which provides a description of this vehicle model.
     + Normative References: [https://schema.org/url](https://schema.org/url)
     + Optional
-    
+
 + `image`: Image which depicts this vehicle model.
     + Normative References: [https://schema.org/image](https://schema.org/image)
     + Optional
@@ -111,19 +113,19 @@ mode (`options=keyValues`).
     },
     "cargoVolume": {
         "value": 1000
-    }, 
+    },
     "modelName": {
         "value": "Econic"
-    }, 
+    },
     "brandName": {
         "value": "Mercedes Benz"
     },
     "manufacturerName": {
         "value": "Daimler"
-    }, 
+    },
     "fuelType": {
         "value": "diesel"
-    }, 
+    },
     "vehicleType": {
         "value": "lorry"
     }

--- a/specs/UrbanMobility/AccessPoint/doc/spec.md
+++ b/specs/UrbanMobility/AccessPoint/doc/spec.md
@@ -8,25 +8,27 @@ It is a GTFS `stop` which `location_type` is equal to `2`.
 
 ## Data Model
 
-+ `id`: Entity Id
-    + It shall be `urn:ngsi-ld:gtfs:AccessPoint:<access_point_identifier>` being `access_point_identifier` a value that can derived from the `stop_id` field. 
+The data model is defined as shown below:
 
-+ `type`: Entity Type 
++ `id`: Entity Id
+    + It shall be `urn:ngsi-ld:gtfs:AccessPoint:<access_point_identifier>` being `access_point_identifier` a value that can derived from the `stop_id` field.
+
++ `type`: Entity Type
     + It shall be equal to `gtfs:AccessPoint`
-  
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 
 The following Attributes shall be as mandated by [gtfs:Stop](../../Stop/doc/spec.md):
- 
-+ `name`   
-+ `code`  
+
++ `name`
++ `code`
 + `page`
 + `description`
 + `location`
@@ -38,32 +40,32 @@ The following Attributes shall be as mandated by [gtfs:Stop](../../Stop/doc/spec
 ### Examples of use 1 (Normalized Format)
 
 ```json
-{ 
+{
     "id": "urn:ngsi-ld:AccessPoint:Madrid:acc_4_1_3",
     "type": "gtfs:AccessPoint",
     "name": {
         "value": "Bravo Murillo"
-    }, 
+    },
     "hasParentStation": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:Station:Madrid:est_90_21"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
+            "type": "Point",
             "coordinates": [
-                -3.69036, 
+                -3.69036,
                 40.46629
             ]
         }
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "Madrid", 
-            "addressCountry": "ES", 
-            "streetAddress": "Calle de Bravo Murillo 377", 
+            "addressLocality": "Madrid",
+            "addressCountry": "ES",
+            "streetAddress": "Calle de Bravo Murillo 377",
             "type": "PostalAddress"
         }
     }
@@ -95,7 +97,7 @@ The following Attributes shall be as mandated by [gtfs:Stop](../../Stop/doc/spec
 
 ### Properties
 
-Same as `gtfs:Stop`. 
+Same as `gtfs:Stop`.
 
 ### Relationships
 

--- a/specs/UrbanMobility/Agency/doc/spec.md
+++ b/specs/UrbanMobility/Agency/doc/spec.md
@@ -6,48 +6,50 @@ See [https://developers.google.com/transit/gtfs/reference/#agencytxt](https://de
 
 ## Data Model
 
-+ `id`: Entity id. 
-    + It shall be `urn:ngsi-ld:gtfs:Agency:<agency_identifier>` being `agency_identifier` a value that can be derived from GTFS `agency_id`. 
+The data model is defined as shown below:
 
-+ `type`: Entity type. 
++ `id`: Entity id.
+    + It shall be `urn:ngsi-ld:gtfs:Agency:<agency_identifier>` being `agency_identifier` a value that can be derived from GTFS `agency_id`.
+
++ `type`: Entity type.
     + It shall be equal to `gtfs:Agency`.
-    
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `source` : A sequence of characters giving the original source of the Entity data as a URL.
-It shall point to the URL of the original GTFS feed used to generate this Entity. 
+It shall point to the URL of the original GTFS feed used to generate this Entity.
     + Attribute type: [URL](https://schema.org/URL)
     + Mandatory
 
 + `name`: Same as GTFS `agency_name`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Mandatory
-    
+
 + `page`: Same as GTFS `agency_url`.
     + Attribute type: Property. [URL](https://schema.org/URL).
     + Optional
-    
+
 + `timezone`: Same as GTFS `agency_timezone`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Allowed values: See [GTFS](https://developers.google.com/transit/gtfs/reference/#agencytxt)
     + Optional
-    
+
 + `phone`: Same as GFTS `agency_phone`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-   
-+ `language`: Same as GTFS `agency_language`. 
+
++ `language`: Same as GTFS `agency_language`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Allowed values: See [GTFS](https://developers.google.com/transit/gtfs/reference/#agencytxt)
     + Optional
-   
-+ `address`: Agency's civic address. 
+
++ `address`: Agency's civic address.
     + Attribute type: Property. [PostalAddress](https://schema.org/PostalAddress)
     + Optional
 
@@ -56,19 +58,19 @@ It shall point to the URL of the original GTFS feed used to generate this Entity
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:Agency:Malaga_EMT",
-    "type": "gtfs:Agency", 
+    "type": "gtfs:Agency",
     "name": {
         "value": "Empresa Malague\u00f1a de Transportes"
-    }, 
+    },
     "language": {
         "value": "ES"
-    }, 
+    },
     "page": {
         "value": "http://www.emtmalaga.es/"
-    }, 
+    },
     "source": {
         "value": "http://datosabiertos.malaga.eu/dataset/lineas-y-horarios-bus-google-transit/resource/24e86888-b91e-45bf-a48c-09855832fd52"
-    }, 
+    },
     "timezone": {
         "value": "Europe/Madrid"
     }
@@ -101,7 +103,7 @@ It shall point to the URL of the original GTFS feed used to generate this Entity
 | `agency_phone`          | `phone`             | `foaf:phone`        |                                                            |
 | `agency_lang`           | `language`          | `dct:language`      |                                                            |
 |                         | `address`           |                     | Agency's [address](https://schema.org/address). Schema.org |
-   
+
 
 ### Relationships
 

--- a/specs/UrbanMobility/ArrivalEstimation/doc/spec.md
+++ b/specs/UrbanMobility/ArrivalEstimation/doc/spec.md
@@ -7,37 +7,39 @@ whilst the vehicle is servicing a particular route.
 
 ## Data Model
 
-+ `id`: Entity Id
-    + It shall be `urn:ngsi-ld:gtfs:ArrivalEstimation:<identifier>`. 
+The data model is defined as shown below:
 
-+ `type`: Entity Type 
++ `id`: Entity Id
+    + It shall be `urn:ngsi-ld:gtfs:ArrivalEstimation:<identifier>`.
+
++ `type`: Entity Type
     + It shall be equal to `ArrivalEstimation`
-  
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `hasStop` : Stop to which this estimation applies to.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Stop](../../Stop/doc/spec.md)
     + Mandatory
-  
-+ `hasTrip` : The trip to which this estimation applies to. 
+
++ `hasTrip` : The trip to which this estimation applies to.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Trip](../../Trip/doc/spec.md)
     + Mandatory
 
-+ `remainingTime`: It shall contain the remaining time of arrival for the trip heading to the concerned stop. 
-    + Attribute type: Property. [Text](https://schema.org/Text). Remaining time shall be encoded as a ISO8601 duration. Ex. `"PT8M5S"`. 
++ `remainingTime`: It shall contain the remaining time of arrival for the trip heading to the concerned stop.
+    + Attribute type: Property. [Text](https://schema.org/Text). Remaining time shall be encoded as a ISO8601 duration. Ex. `"PT8M5S"`.
     + Attribute Metadata:
         + `timestamp` (mapped to `observedAt` in NGSI-LD). Timestamp of the last attribute update
             + Type: [DateTime](https://schema.org/DateTime)
             + Mandatory
     + Mandatory
-  
-+ `remainingDistance`: It shall contain  the remaining distance (in meters) of arrival for the trip heading to the concerned stop. 
+
++ `remainingDistance`: It shall contain  the remaining distance (in meters) of arrival for the trip heading to the concerned stop.
     + Attribute type: Property. Positive Number. [https://schema.org/Number](https://schema.org/Number)
     + Attribute metadata:
         + `timestamp` (mapped to `observedAt` in NGSI-LD). Timestamp of the last attribute update
@@ -45,7 +47,7 @@ whilst the vehicle is servicing a particular route.
             + Mandatory
     + Default Unit: Meters
     + Optional
-  
+
 + `headSign`: It shall contain the text that appears on a sign that identifies the trip's destination to passengers.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Mandatory
@@ -57,19 +59,19 @@ whilst the vehicle is servicing a particular route.
     "id": "urn:ngsi-ld:ArrivalEstimation:L5C1_Stop74_1",
     "type": "ArrivalEstimation",
     "hasTrip": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Trip:tus:5C1"
-    }, 
+    },
     "headSign": {
         "value": "Plaza Italia"
-    }, 
+    },
     "remainingTime": {
         "value": "PT8M5S"
-    }, 
+    },
     "hasStop": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Stop:tus:74"
-    }, 
+    },
     "remainingDistance": {
         "value": 1200
     }

--- a/specs/UrbanMobility/CalendarDateRule/doc/spec.md
+++ b/specs/UrbanMobility/CalendarDateRule/doc/spec.md
@@ -6,24 +6,26 @@ See [https://developers.google.com/transit/gtfs/reference/#calendar_datestxt](ht
 
 ## Data Model
 
-+ `id`: Entity Id
-    + It shall be `urn:ngsi-ld:gtfs:CalendarDateRule:<calendar_date_rule_identifier>`. 
+The data model is defined as shown below:
 
-+ `type`: Entity Type 
++ `id`: Entity Id
+    + It shall be `urn:ngsi-ld:gtfs:CalendarDateRule:<calendar_date_rule_identifier>`.
+
++ `type`: Entity Type
     + It shall be equal to `gtfs:CalendarDateRule`
-  
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `hasService` : Service to which this rule applies to. Derived from `service_id`.
     + Attribute type: Relationship. It shall point to an entity of Type [gtfs:Service](../../Service/doc/spec.md)
     + Mandatory
-  
+
 + `name` : Name given to this rule.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
@@ -31,9 +33,9 @@ See [https://developers.google.com/transit/gtfs/reference/#calendar_datestxt](ht
 + `description`: Description given to this rule.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-  
-+ `appliesOn`: Date (in YYYY-MM-DD format) this rule applies to. It shall be obtained from the GTFS `date` field. 
-    + Attribute type: Property. [Date](https://schema.org/Date). 
+
++ `appliesOn`: Date (in YYYY-MM-DD format) this rule applies to. It shall be obtained from the GTFS `date` field.
+    + Attribute type: Property. [Date](https://schema.org/Date).
     + Mandatory
 
 + `exceptionType`: Same as GTFS `exception_type` field. Allowed values: (`"1"`, `"2"`)
@@ -45,17 +47,17 @@ See [https://developers.google.com/transit/gtfs/reference/#calendar_datestxt](ht
 ```json
 {
     "id": "urn:ngsi-ld:CalendarDateRule:Malaga:Rule67",
-    "type": "gtfs:CalendarDateRule", 
+    "type": "gtfs:CalendarDateRule",
     "name": {
         "value": "Rule Fair Area"
-    }, 
+    },
     "exceptionType": {
         "value": "1"
-    }, 
+    },
     "hasService": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:Service:Malaga:FairArea_1"
-    }, 
+    },
     "appliesOn": {
         "value": "2018-03-19"
     }
@@ -84,7 +86,7 @@ See [https://developers.google.com/transit/gtfs/reference/#calendar_datestxt](ht
 | `date`                    | `appliesOn`             | `dct:date`                  |                                                            |
 | `exception_type`          | `exceptionType`         |                             |                                                            |
 
-                              
+
 
 
 ### Relationships

--- a/specs/UrbanMobility/CalendarRule/doc/spec.md
+++ b/specs/UrbanMobility/CalendarRule/doc/spec.md
@@ -6,24 +6,26 @@ See [https://developers.google.com/transit/gtfs/reference/#calendartxt](https://
 
 ## Data Model
 
-+ `id`: Entity Id
-    + It shall be `urn:ngsi-ld:gtfs:CalendarRule:<calendar_rule_identifier>`. 
+The data model is defined as shown below:
 
-+ `type`: Entity Type 
++ `id`: Entity Id
+    + It shall be `urn:ngsi-ld:gtfs:CalendarRule:<calendar_rule_identifier>`.
+
++ `type`: Entity Type
     + It shall be equal to `gtfs:CalendarRule`
-  
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `hasService` : Service to which this rule applies to. Derived from `service_id`.
     + Attribute type: Relationship. It shall point to an entity of Type [gtfs:Service](../../Service/doc/spec.md)
     + Mandatory
-  
+
 + `name` : Name of this rule
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
@@ -31,7 +33,7 @@ See [https://developers.google.com/transit/gtfs/reference/#calendartxt](https://
 + `description`: Description of this rule
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-  
+
 + `monday`: Same as GTFS `monday`
     + Attribute type: Property. [https://schema.org/Boolean](https://schema.org/Boolean)
     + Mandatory
@@ -59,55 +61,55 @@ See [https://developers.google.com/transit/gtfs/reference/#calendartxt](https://
 + `sunday`: Same as GTFS `sunday`
     + Attribute type: Property. [https://schema.org/Boolean](https://schema.org/Boolean)
     + Mandatory
-  
+
 + `startDate`: Start date of this rule in `YYYY-MM-DD` format.
 It can be obtained from the field `start_date` of [calendar.txt](https://developers.google.com/transit/gtfs/reference/#calendartxt).
-    + Attribute type: Property. [https://schema.org/Date](https://schema.org/Date). 
+    + Attribute type: Property. [https://schema.org/Date](https://schema.org/Date).
     + Mandatory
-  
+
 + `endDate`: End date of this rule in `YYYY-MM-DD` format.
 It can be obtained from the field `end_date` of [calendar.txt](https://developers.google.com/transit/gtfs/reference/#calendartxt).
-    + Attribute type: Property. [https://schema.org/Date](https://schema.org/Date). 
+    + Attribute type: Property. [https://schema.org/Date](https://schema.org/Date).
     + Mandatory
-  
+
 
 ### Examples of use 1 (Normalized Format)
 
 ```json
 {
     "id": "urn:ngsi-ld:CalendarRule:Madrid:Rule1267",
-    "type": "gtfs:CalendarRule", 
+    "type": "gtfs:CalendarRule",
     "startDate": {
         "value": "2018-01-01"
-    }, 
+    },
     "endDate": {
         "value": "2019-01-01"
-    }, 
+    },
     "name": {
         "value": "Rule Hospital Service 1"
-    }, 
+    },
     "monday": {
         "value": true
-    }, 
+    },
     "tuesday": {
         "value": true
-    }, 
+    },
     "friday": {
         "value": true
-    }, 
+    },
     "wednesday": {
         "value": true
-    }, 
+    },
     "thursday": {
         "value": true
-    },  
+    },
     "sunday": {
         "value": false
-    }, 
+    },
     "hasService": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:Service:Madrid:Hospital_1"
-    }, 
+    },
     "saturday": {
         "value": false
     }
@@ -149,7 +151,7 @@ It can be obtained from the field `end_date` of [calendar.txt](https://developer
 | `sunday`                  | `sunday`                | `gtfs:sunday`               |                                                            |
 | `start_date`              | `startDate`             | `schema:startDate`          |                                                            |
 | `end_date`                | `endDate`               | `schema:endDate`            |                                                            |
-                              
+
 
 
 ### Relationships

--- a/specs/UrbanMobility/Frequency/doc/spec.md
+++ b/specs/UrbanMobility/Frequency/doc/spec.md
@@ -6,20 +6,22 @@ See [https://developers.google.com/transit/gtfs/reference/#frequenciestxt](https
 
 ## Data Model
 
-+ `id`: Entity id. 
-    + It shall be `urn:ngsi-ld:gtfs:Frequency:<frequency_identifier>`. 
+The data model is defined as shown below:
 
-+ `type`: Entity type. 
++ `id`: Entity id.
+    + It shall be `urn:ngsi-ld:gtfs:Frequency:<frequency_identifier>`.
+
++ `type`: Entity type.
     + It shall be equal to `gtfs:Frequency`.
-    
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `name` : Name given to this frequency.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
@@ -27,7 +29,7 @@ See [https://developers.google.com/transit/gtfs/reference/#frequenciestxt](https
 + `description`: Description given to this frequency.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-  
+
 + `hasTrip`: Trip associated to this Entity.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Trip](../../Trip/doc/spec.md)
     + Mandatory
@@ -35,43 +37,43 @@ See [https://developers.google.com/transit/gtfs/reference/#frequenciestxt](https
 + `startTime`: Same as GTFS `start_time`. See [format](https://developers.google.com/transit/gtfs/reference/#frequenciestxt).
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Mandatory
-    
+
 + `endTime`: Same as GTFS `end_time`. See [format](https://developers.google.com/transit/gtfs/reference/#frequenciestxt).
     + Attribute type: Property. [Text](https://schema.org/Text).
-    + Mandatory   
-    
+    + Mandatory
+
 + `headwaySeconds`: Same as GTFS `headway_secs`.
     + Attribute type: Property. [Integer](https://schema.org/Integer).
     + Mandatory
-    
+
 + `exactTimes`: Same as GTFS `exact_times` but encoded as a Boolean:
 `false`: Frequency-based trips are not exactly scheduled.
 `true`: Frequency-based trips are exactly scheduled.
-    + Attribute type: Property. [Boolean](https://schema.org/Boolean). 
+    + Attribute type: Property. [Boolean](https://schema.org/Boolean).
     + Optional
-    
+
 ### Example of use 1 (Normalized Format)
 
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:Frequency:Malaga:Linea1",
-    "type": "gtfs:Frequency", 
+    "type": "gtfs:Frequency",
     "description": {
         "value": "Cada 10 minutos"
-    }, 
+    },
     "hasTrip": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Trip:Spain:Malaga:1"
-    }, 
+    },
     "headwaySeconds": {
         "value": 600
-    }, 
+    },
     "startTime": {
         "value": "07:00:00"
-    }, 
+    },
     "endTime": {
         "value": "10:25:00"
-    }, 
+    },
     "name": {
         "value": "Laborables"
     }
@@ -105,7 +107,7 @@ See [https://developers.google.com/transit/gtfs/reference/#frequenciestxt](https
 | `exact_times`           | `exactTimes`        | `gtfs:exactTimes`     |                                                              |
 |                         | `name`              | `schema:name`         |                                                              |
 |                         | `description`       | `schema:description`  |                                                              |
-   
+
 
 ### Relationships
 

--- a/specs/UrbanMobility/Route/doc/spec.md
+++ b/specs/UrbanMobility/Route/doc/spec.md
@@ -6,76 +6,78 @@ See [https://developers.google.com/transit/gtfs/reference/#routestxt](https://de
 
 ## Data Model
 
-+ `id`: Entity id. 
-    + It shall be `urn:ngsi-ld:gtfs:Route:<route_identifier>` being `route_identifier` a value that can be derived from GTFS `route_id`. 
+The data model is defined as shown below:
 
-+ `type`: Entity type. 
++ `id`: Entity id.
+    + It shall be `urn:ngsi-ld:gtfs:Route:<route_identifier>` being `route_identifier` a value that can be derived from GTFS `route_id`.
+
++ `type`: Entity type.
     + It shall be equal to `gtfs:Route`.
-    
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `shortName`: Same as GTFS `route_short_name`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Mandatory
-    
+
 + `name`: Same as GTFS `route_long_name`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Mandatory
-    
+
 + `description`: Same as GTFS `route_desc`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Optional
-    
+
 + `routeType`: Same as GTFS `route_type`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Allowed values: Those allowed for `route_type` as prescribed by [GTFS](https://developers.google.com/transit/gtfs/reference/#routestxt)
     + Mandatory
-    
+
 + `page`: Same as GTFS `route_url`.
     + Attribute type: Property. [URL](https://schema.org/URL).
     + Optional
-    
+
 + `routeColor`: Same as GTFS `route_color`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Allowed values: See [GTFS](https://developers.google.com/transit/gtfs/reference/#routestxt)
     + Optional
-    
+
 + `routeTextColor`: Same as GFTS `route_text_color`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-   
-+ `routeSortOrder`: Same as GTFS `route_sort_order`. 
+
++ `routeSortOrder`: Same as GTFS `route_sort_order`.
     + Attribute type: Property. [Number](https://schema.org/Number)
     + Optional
 
 + `operatedBy` : Agency that operates this route.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Agency](../../Agency/doc/spec.md)
     + Mandatory
-   
+
 ### Example of use 1 (Normalized Format)
 
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:Route:Spain:Malaga:1",
-    "type": "gtfs:Route", 
+    "type": "gtfs:Route",
     "name": {
         "value": "Parque del Sur _ Alameda Principal _ San Andr\u00e9s"
-    }, 
+    },
     "shortName": {
         "value": "1"
-    }, 
+    },
     "page": {
         "value": "http://www.emtmalaga.es/emt-mobile/informacionLinea.html"
-    }, 
+    },
     "routeType": {
         "value": "3"
-    }, 
+    },
     "operatedBy": {
         "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Agency:Malaga_EMT"

--- a/specs/UrbanMobility/Service/doc/spec.md
+++ b/specs/UrbanMobility/Service/doc/spec.md
@@ -6,46 +6,48 @@ It represents a transportation service which is available for one or more routes
 
 ## Data Model
 
+The data model is defined as shown below:
+
 + `id`: Entity Id
     + It shall be `urn:ngsi-ld:gtfs:Service:<service_identifier>`. It can be derived from the `service_id` field of [trips.txt](https://developers.google.com/transit/gtfs/reference/#tripstxt) and/or
 [calendar.txt](https://developers.google.com/transit/gtfs/reference/#calendartxt)
 
-+ `type`: Entity Type 
++ `type`: Entity Type
     + It shall be equal to `gtfs:Service`
-  
+
 + `dateCreated`: Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified`: Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `name`: Service name.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Mandatory
-  
+
 + `description`: Service description.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-  
+
 + `operatedBy`: Agency that operates this service.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Agency](../../Agency/doc/spec.md)
     + Mandatory
-  
+
 ### Examples of use 1 (Normalized Format)
 
 ```json
 {
-    "id": "urn:ngsi-ld:Service:Malaga:LAB", 
-    "type": "gtfs:Service", 
+    "id": "urn:ngsi-ld:Service:Malaga:LAB",
+    "type": "gtfs:Service",
     "operatedBy": {
         "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Agency:Malaga_EMT"
-    }, 
+    },
     "name": {
         "value": "LAB"
-    }, 
+    },
     "description": {
         "value": "Laborables"
     }
@@ -72,7 +74,7 @@ It represents a transportation service which is available for one or more routes
 |:--------------------------|:------------------------|:--------------------------- |:-----------------------------------------------------------|
 |                           | `name`                  | `schema:name`               |                                                            |
 |                           | `description`           | `schema:description`        |                                                            |
-                              
+
 
 
 ### Relationships

--- a/specs/UrbanMobility/Station/doc/spec.md
+++ b/specs/UrbanMobility/Station/doc/spec.md
@@ -8,28 +8,30 @@ It is a GTFS `stop` which `location_type` is equal to `1`.
 
 ## Data Model
 
-+ `id`: Entity Id
-    + It shall be `urn:ngsi-ld:gtfs:Station:<station_identifier>` being `station_identifier` a value that can derived from the `stop_id` field. 
+The data model is defined as shown below:
 
-+ `type`: Entity Type 
++ `id`: Entity Id
+    + It shall be `urn:ngsi-ld:gtfs:Station:<station_identifier>` being `station_identifier` a value that can derived from the `stop_id` field.
+
++ `type`: Entity Type
     + It shall be equal to `gtfs:Station`
- 
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-    
-+ `hasStop` : It shall point to another Entity(ies) of type `gtfs:Stop`  
-    + Type: Relationship. List of [gtfs:Stop](../../Stop/doc/spec.md). 
+
++ `hasStop` : It shall point to another Entity(ies) of type `gtfs:Stop`
+    + Type: Relationship. List of [gtfs:Stop](../../Stop/doc/spec.md).
     + Mandatory
-  
-+ `hasAccessPoint` : It shall point to another Entity(ies) of type `gtfs:AccessPoint`  
-    + Type: Relationship. List of [gtfs:AccessPoint](../../AccessPoint/doc/spec.md). 
-    + Optional  
- 
+
++ `hasAccessPoint` : It shall point to another Entity(ies) of type `gtfs:AccessPoint`
+    + Type: Relationship. List of [gtfs:AccessPoint](../../AccessPoint/doc/spec.md).
+    + Optional
+
 The specification for the following attributes is the one mandanted by [gtfs:Stop](../../Stop/doc/spec.md):
 
 + `name`
@@ -38,43 +40,43 @@ The specification for the following attributes is the one mandanted by [gtfs:Sto
 + `description`
 + `location`
 + `wheelChairAccessible`
-+ `zoneCode` 
++ `zoneCode`
 + `address`
-+ `hasParentStation` 
++ `hasParentStation`
 
 ### Example 1 (Normalized Format)
 
 ```json
 {
     "id": "urn:ngsi-ld:Station:Madrid:est_90_21",
-    "type": "gtfs:Station", 
+    "type": "gtfs:Station",
     "code": {
         "value": "21"
-    }, 
+    },
     "name": {
         "value": "Intercambiador de Plaza de Castilla"
-    }, 
+    },
     "hasStop": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": [
             "urn:ngsi-ld:gtfs:Stop:Madrid_par_4_1"
         ]
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
+            "type": "Point",
             "coordinates": [
-                -3.6892, 
+                -3.6892,
                 40.4669
             ]
         }
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "Madrid", 
-            "addressCountry": "ES", 
+            "addressLocality": "Madrid",
+            "addressCountry": "ES",
             "streetAddress": "Paseo de la Castellana 189"
         }
     }

--- a/specs/UrbanMobility/Stop/doc/spec.md
+++ b/specs/UrbanMobility/Stop/doc/spec.md
@@ -8,55 +8,57 @@ It represents a GTFS `stop` which `location_type` shall be equal to `0`.
 
 ## Data Model
 
-+ `id`: Entity Id
-    + It shall be `urn:ngsi-ld:gtfs:Stop:<stop_identifier>` being `stop_identifier` a value that can derived from the GTFS `stop_id` field. 
+The data model is defined as shown below:
 
-+ `type`: Entity Type 
++ `id`: Entity Id
+    + It shall be `urn:ngsi-ld:gtfs:Stop:<stop_identifier>` being `stop_identifier` a value that can derived from the GTFS `stop_id` field.
+
++ `type`: Entity Type
     + It shall be equal to `gtfs:Stop`
- 
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
-  
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
-+ `name`: Same as GTFS `stop_name`. 
+
++ `name`: Same as GTFS `stop_name`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Mandatory
-  
-+ `code`: Same as GTFS `stop_code`. 
+
++ `code`: Same as GTFS `stop_code`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-  
-+ `page`: Same as GTFS `stop_url`. 
+
++ `page`: Same as GTFS `stop_url`.
     + Attribute type: Property. [URL](https://schema.org/URL)
     + Optional
-  
-+ `description`: Same as GTFS `stop_desc`. 
+
++ `description`: Same as GTFS `stop_desc`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
- 
+
 + `location`: Stop's location encoded as GeoJSON Point which coordinates shall be in the form [`stop_long`,`stop_lat`].
     + Attribute type: GeoProperty. `geo:json`.
     + Normative References: [rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
 
-+ `wheelChairAccessible`: Same as GTFS `wheelchair_boarding`. 
++ `wheelChairAccessible`: Same as GTFS `wheelchair_boarding`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Allowed values: (`0`, `1`, `2`) as per the [GTFS](https://developers.google.com/transit/gtfs/reference/#stopstxt)
     + Optional
-  
-+ `zoneCode` : Transport zone to which this stop belongs to. Same as GTFS `zone_id`. 
+
++ `zoneCode` : Transport zone to which this stop belongs to. Same as GTFS `zone_id`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
 
-+ `address`: Stop's civic address. 
++ `address`: Stop's civic address.
     + Attribute type: Property. [PostalAddress](https://schema.org/PostalAddress)
     + Optional
-  
-+ `hasParentStation` : Same as GTFS `parent_station`.  
+
++ `hasParentStation` : Same as GTFS `parent_station`.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Station](../../Station/doc/spec.md)
     + Optional
 
@@ -69,24 +71,24 @@ It represents a GTFS `stop` which `location_type` shall be equal to `0`.
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:Stop:Malaga_101",
-    "type": "gtfs:Stop", 
+    "type": "gtfs:Stop",
     "code": {
         "value": "101"
-    }, 
+    },
     "operatedBy": {
         "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Agency:Malaga_EMT"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
+            "type": "Point",
             "coordinates": [
-                -4.424393, 
+                -4.424393,
                 36.716872
             ]
         }
-    }, 
+    },
     "name": {
         "value": "Alameda Principal Sur"
     }
@@ -109,14 +111,14 @@ It represents a GTFS `stop` which `location_type` shall be equal to `0`.
 }
 ```
 
-  
-## Summary of mappings to GTFS  
+
+## Summary of mappings to GTFS
 
 ### Properties
 
 | GTFS Field              | NGSI Attribute         | LinkedGTFS                    | Comment                                                   |
 |:----------------------- |:-----------------------|:------------------------------|:----------------------------------------------------------|
-| `stop_name`             | `name`                 | `foaf:name`                   |                                                           |     
+| `stop_name`             | `name`                 | `foaf:name`                   |                                                           |
 | `stop_code`             | `code`                 | `gtfs:code`                   |                                                           |
 | `stop_url`              | `page`                 | `foaf:page`                   |                                                           |
 | `stop_desc`             | `description`          | `dct:description`             |                                                           |

--- a/specs/UrbanMobility/StopTime/doc/spec.md
+++ b/specs/UrbanMobility/StopTime/doc/spec.md
@@ -6,20 +6,22 @@ See [https://developers.google.com/transit/gtfs/reference/#stop_timestxt](https:
 
 ## Data Model
 
-+ `id`: Entity id. 
-    + It shall be `urn:ngsi-ld:gtfs:StopTime:<stop_time_identifier>` being `stop_time_identifier` a value that can be derived from GTFS `trip_id` and `stop_id`. 
+The data model is defined as shown below:
 
-+ `type`: Entity type. 
++ `id`: Entity id.
+    + It shall be `urn:ngsi-ld:gtfs:StopTime:<stop_time_identifier>` being `stop_time_identifier` a value that can be derived from GTFS `trip_id` and `stop_id`.
+
++ `type`: Entity type.
     + It shall be equal to `gtfs:StopTime`.
-    
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified`: Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `hasTrip`: Same as GTFS `trip_id`.
     + Attribute type: Relationship. It shall point to an Entity of type [gtfs:Trip](../../Trip/doc/spec.md)
     + Mandatory
@@ -65,25 +67,25 @@ See [https://developers.google.com/transit/gtfs/reference/#stop_timestxt](https:
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:StopTime:Spain:Madrid:EMT:FE0010011_737",
-    "type": "gtfs:StopTime", 
+    "type": "gtfs:StopTime",
     "departureTime": {
         "value": "07:04:24"
-    }, 
+    },
     "hasTrip": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Trip:Madrid:EMT:FE0010011"
-    }, 
+    },
     "stopSequence": {
         "value": 4
-    }, 
+    },
     "distanceTravelled": {
         "value": 759
-    }, 
+    },
     "arrivalTime": {
         "value": "07:04:24"
-    }, 
+    },
     "hasStop": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Stop:Madrid:EMT:737"
     }
 }

--- a/specs/UrbanMobility/TransferRule/doc/spec.md
+++ b/specs/UrbanMobility/TransferRule/doc/spec.md
@@ -6,20 +6,22 @@ See [https://developers.google.com/transit/gtfs/reference/#transferstxt](https:/
 
 ## Data Model
 
-+ `id`: Entity id. 
-    + It shall be `urn:ngsi-ld:gtfs:TransferRule:<transfer_rule_identifier>`. 
+The data model is defined as shown below:
 
-+ `type`: Entity type. 
++ `id`: Entity id.
+    + It shall be `urn:ngsi-ld:gtfs:TransferRule:<transfer_rule_identifier>`.
+
++ `type`: Entity type.
     + It shall be equal to `gtfs:Transfer`.
-    
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified` : Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `name` : Name given to this transfer rule.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
@@ -27,45 +29,45 @@ See [https://developers.google.com/transit/gtfs/reference/#transferstxt](https:/
 + `description`: Description given to this transfer rule.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-  
+
 + `hasOrigin`: Trip associated to this Entity.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Stop](../../Stop/doc/spec.md) or [gtfs:Station](../../Station/doc/spec.md)
     + Mandatory
-  
+
 + `hasDestination`: Trip associated to this Entity.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Stop](../../Stop/doc/spec.md) or [gtfs:Station](../../Station/doc/spec.md)
     + Mandatory
-  
+
 + `transferType`: Same as GTFS `transfer_type`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Allowed values: (`"0"`,`"1"`,`"2"`,`"3"`)
     + Mandatory
-    
-+ `minimumTransferTime`: Same as GTFS `min_transfer_time`. 
+
++ `minimumTransferTime`: Same as GTFS `min_transfer_time`.
     + Attribute type: Property. [Integer](https://schema.org/Integer).
     + Default unit: seconds
-    + Optional   
-        
+    + Optional
+
 ### Example 1 (Normalized Format)
 
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:TransferRule:Malaga:Linea1_Linea5",
-    "type": "gtfs:TransferRule", 
+    "type": "gtfs:TransferRule",
     "transferType": {
         "value": "0"
-    }, 
+    },
     "minimumTransferTime": {
         "value": 10
-    }, 
+    },
     "hasDestination": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Stop:Malaga_508"
-    }, 
+    },
     "hasOrigin": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Stop:Malaga_101"
-    }, 
+    },
     "name": {
         "value": "L1_L5"
     }
@@ -96,7 +98,7 @@ See [https://developers.google.com/transit/gtfs/reference/#transferstxt](https:/
 | `minimumTransferTime`   | `min_tranfer_time`  | `gtfs:minimumTransferTime` |                                                              |
 |                         | `name`              | `schema:name`              |                                                              |
 |                         | `description`       | `schema:description`       |                                                              |
-   
+
 
 ### Relationships
 

--- a/specs/UrbanMobility/Trip/doc/spec.md
+++ b/specs/UrbanMobility/Trip/doc/spec.md
@@ -6,56 +6,58 @@ See [https://developers.google.com/transit/gtfs/reference/#tripstxt](https://dev
 
 ## Data Model
 
-+ `id`: Entity id. 
-    + It shall be `urn:ngsi-ld:gtfs:Trip:<trip_identifier>` being `trip_identifier` a value that can be derived from GTFS `trip_id`. 
+The data model is defined as shown below:
 
-+ `type`: Entity type. 
++ `id`: Entity id.
+    + It shall be `urn:ngsi-ld:gtfs:Trip:<trip_identifier>` being `trip_identifier` a value that can be derived from GTFS `trip_id`.
+
++ `type`: Entity type.
     + It shall be equal to `gtfs:Trip`.
-    
+
 + `dateCreated` : Entity's creation timestamp.
     + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated. 
- 
+    + Read-Only. Automatically generated.
+
 + `dateModified`: Last update timestamp of this Entity.
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
-  
+
 + `headSign`: Same as GTFS `trip_headsign`.
     + Attribute type: Property. [Text](https://schema.org/Text).
-    + Optional 
-  
+    + Optional
+
 + `shortName`: Same as GTFS `trip_short_name`.
     + Attribute type: Property. [Text](https://schema.org/Text).
     + Optional
-    
+
 + `direction`: Same as GTFS `direction_id`.
     + Attribute type: Property. [Number](https://schema.org/Number).
-    + Allowed Values: `0` and `1` as per GTFS `direction_id`. 
+    + Allowed Values: `0` and `1` as per GTFS `direction_id`.
     + Optional
-    
+
 + `block`: Same as GTFS `block_id`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Optional
-  
+
 + `hasService`: Same as GTFS `service_id`.
-    + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Service](../../Service/doc/spec.md) 
+    + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Service](../../Service/doc/spec.md)
     + Optional
-  
+
 + `location`: The geographical shape associated to the trip encoded as GeoJSON `LineString` or `MultiLineString`.
-The coordinates shall be obtained from the `shapes.txt` feed file as per the value of `shape_id`. 
+The coordinates shall be obtained from the `shapes.txt` feed file as per the value of `shape_id`.
     + Attribute type: GeoProperty. `geo:json`
     + Optional
-     
+
 + `hasRoute`: Same as `route_id`.
     + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Route](../../Route/doc/spec.md)
     + Mandatory
 
-+ `wheelChairAccessible`: Same as GTFS `wheelchair_accessible`. 
++ `wheelChairAccessible`: Same as GTFS `wheelchair_accessible`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Allowed values: (`0`, `1`, `2`) as per the [GTFS](https://developers.google.com/transit/gtfs/reference/#tripstxt)
     + Optional
 
-+ `bikesAllowed`: Same as GTFS `bikes_allowed`. 
++ `bikesAllowed`: Same as GTFS `bikes_allowed`.
     + Attribute type: Property. [Text](https://schema.org/Text)
     + Allowed values: (`0`, `1`, `2`) as per the [GTFS](https://developers.google.com/transit/gtfs/reference/#tripstxt)
     + Optional
@@ -66,40 +68,40 @@ The coordinates shall be obtained from the `shapes.txt` feed file as per the val
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:Trip:Spain:Malaga:1",
-    "type": "gtfs:Trip", 
+    "type": "gtfs:Trip",
     "direction": {
         "value": 0
-    }, 
+    },
     "headSign": {
         "value": "San Andr\u00e9s"
-    }, 
+    },
     "hasRoute": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Route:Spain:Malaga:1"
-    }, 
+    },
     "hasService": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "urn:ngsi-ld:gtfs:Service:Malaga_LAB"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "LineString", 
+            "type": "LineString",
             "coordinates": [
                 [
-                    -4.421394, 
+                    -4.421394,
                     36.73826
-                ], 
+                ],
                 [
-                    -4.421428, 
+                    -4.421428,
                     36.73825
-                ], 
+                ],
                 [
-                    -4.421505, 
+                    -4.421505,
                     36.738186
-                ], 
+                ],
                 [
-                    -4.421525, 
+                    -4.421525,
                     36.738033
                 ]
             ]

--- a/specs/WasteManagement/WasteContainerIsle/doc/spec.md
+++ b/specs/WasteManagement/WasteContainerIsle/doc/spec.md
@@ -2,46 +2,48 @@
 
 ## Description
 
-A geographical area which keeps one or more waste containers. 
+A geographical area which keeps one or more waste containers.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
 
-+ `type` : Entity type. It must be equal to `WasteContainerIsle`. 
++ `id` : Unique identifier.
+
++ `type` : Entity type. It must be equal to `WasteContainerIsle`.
 
 + `location` : Location of the isle represented by a GeoJSON Polygon.
     + Attribute type: `geo:json`.
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
-  
-+ `address` : Civic address where the isle is located. 
+
++ `address` : Civic address where the isle is located.
     + Normative References: [https://schema.org/address](https://schema.org/address)
     + Optional
- 
+
 + `name` : Name given to the isle
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Optional
 
-+ `description` : Description about the isle. 
++ `description` : Description about the isle.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
-    
+
 + `insertHolesNumber` : Number of insert holes the isle has.
     + Attribute type: [Number](https://schema.org/Number).
     + Optional
-    
+
 + `features` : A list of features provided by the isle.
     + Attribute type: List of [Text](http://schema.org/Text).
     + Allowed values:
         + `containerFix`. Allows to fix containers to a permanent position.
         + `fenced`. The isle is properly fenced.
-        + `underground`. The isle allows to hold buried containers. 
+        + `underground`. The isle allows to hold buried containers.
         + Any other value meaningful to the application.
     + Optional
 
 + `refWasteContainer` : List of containers present in the isle.
-    + Attribute type: List of references to [WasteContainer](../../WasteContainer/doc/spec.md) entities. 
+    + Attribute type: List of references to [WasteContainer](../../WasteContainer/doc/spec.md) entities.
     + Allowed values. Container's id.
     + Optional
 
@@ -49,7 +51,7 @@ A geographical area which keeps one or more waste containers.
 responsible, district, neighbourhood, etc.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-    
+
 + `dateModified` : Last update timestamp of this entity
     + Attribute type: [DateTime](https://schema.org/DateTime)
     + Read-Only. Automatically generated.
@@ -80,7 +82,7 @@ mode (`options=keyValues`).
             [ -3.164394553567159, 40.627772099765778 ],
             [ -3.164424899616589, 40.62775018317452 ],
             [ -3.164485591715449, 40.62785133667262 ]
-          ]  
+          ]
          ]
       },
       "address": {
@@ -91,9 +93,9 @@ mode (`options=keyValues`).
       "features": ["underground"],
       "name": "Dr. Fleming 12, Esquina Manuel Paez Xaramillo",
       "description": "Container isle located downtown",
-      "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"] 
+      "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"]
     }
-    
+
 ## Test it with a real service
 
 T.B.D.

--- a/specs/WasteManagement/WasteContainerModel/doc/spec.md
+++ b/specs/WasteManagement/WasteContainerModel/doc/spec.md
@@ -2,17 +2,19 @@
 
 ## Description
 
-A model of waste container which captures the static properties of a class of containers. 
+A model of waste container which captures the static properties of a class of containers.
 
 ## Data Model
 
-+ `id` : Unique identifier. 
+The data model is defined as shown below:
+
++ `id` : Unique identifier.
 
 + `type`: Entity Type. It must be equal to `WasteContainerModel`.
 
 + `name`. Name given to this container model. It is a "well-known", mnemotechnic or codename.
 This attribute is different than `modelName` which conveys the formal model name given by the
-manufacturer. 
+manufacturer.
     + Normative References: [https://schema.org/name](https://schema.org/name)
     + Mandatory
 
@@ -20,13 +22,13 @@ manufacturer.
     + Attribute type: [Number](https://schema.org/Number).
     + Default Unit: Meters
     + See also: [https://schema.org/width](https://schema.org/width)
-    + Optional 
+    + Optional
 
-+ `height`. Height of the container. 
++ `height`. Height of the container.
     + Attribute type: [Number](https://schema.org/Number).
     + Default Unit: Meters
     + See also: [https://schema.org/height](https://schema.org/height)
-    + Optional 
+    + Optional
 
 + `depth`. Depth of the container.
     + Attribute type: [Number](https://schema.org/Number).
@@ -45,7 +47,7 @@ manufacturer.
     + Normative References: [https://schema.org/cargoVolume](https://schema.org/cargoVolume)
     + Default Unit: liters
     + Optional
-       
+
 + `maximumLoad`. Maximum load the container can hold safely.
     + Attribute type: [Number](https://schema.org/Number).
     + Default Unit: Kilograms
@@ -56,45 +58,45 @@ manufacturer.
     + Default Unit: Kilograms
     + Optional
 
-+ `category`. Container’s category. 
++ `category`. Container’s category.
     + Attribute type: List of [Text](https://schema.org/Text).
     + Allowed values (Informative):
         + `dumpster`. See [https://en.wikipedia.org/wiki/Dumpster](https://en.wikipedia.org/wiki/Dumpster)
         + `trashCan`.
         + `wheelieBin`.
-        + Any other category relevant for the application. 
+        + Any other category relevant for the application.
     + Optional
-  
+
 + `insertHolesNumber`. Number of insert holes the container has.
     + Attribute type: [Number](https://schema.org/Number).
     + Optional
 
-+ `madeOf`. Material the container is made of. 
++ `madeOf`. Material the container is made of.
     + Attribute type: [Text](https://schema.org/Text)
     + Allowed values: one Of (`plastic`, `wood` , `metal`, `other`)
     + Optional
-    
+
 + `madeOfCode`. Material Code as per standard tables. TBD.
     + Attribute type: [Text](https://schema.org/Text)
     + Optional
-       
+
 + `brandName`. Name of the brand.
     + Attribute type: [Text](https://schema.org/Text)
     + See also: [https://schema.org/brand](https://schema.org/brand)
     + Optional
-       
+
 + `modelName`. Name of the model as given by the manufacturer.
-This attribute is different than `name` which is just a codename usually given by municipalities. 
+This attribute is different than `name` which is just a codename usually given by municipalities.
     + Attribute type: [Text](https://schema.org/Text)
     + See also: [https://schema.org/model](https://schema.org/model)
     + Optional
-    
+
 + `manufacturerName`. Name of the manufacturer.
     + Attribute type: [Text](https://schema.org/Text)
     + See also: [https://schema.org/model](https://schema.org/manufacturer)
     + Optional
-    
-+ `description`. Description about the waste container model. 
+
++ `description`. Description about the waste container model.
     + Normative References: [https://schema.org/description](https://schema.org/description)
     + Optional
 
@@ -114,7 +116,7 @@ This attribute is different than `name` which is just a codename usually given b
     + AttributeType: List of [Text](https://schema.org/Text).
     + Optional
 
-+ `features`. A list of container features. 
++ `features`. A list of container features.
     + Attribute type: List of [Text](https://schema.org/Text)
     + Allowed Values:
         + `wheels`


### PR DESCRIPTION
* Added pre-amble text
* Removed trailing spaces.

This is a FIWARE CSS compatibility issue between offering a ToC on the unstyled markdown
and not offering a ToC on RTD. The first UL after the first h1 or h2 is deliberated suppressed
Fixed by adding a pre-amble to the list explaining what the model is about.