### PR TITLE
Add refDevice attribute into the Streetlight and to the StreetlightControlCabinet models

### DIFF
--- a/specs/StreetLighting/Streetlight/doc/spec.md
+++ b/specs/StreetLighting/Streetlight/doc/spec.md
@@ -75,6 +75,11 @@ The data model is defined as shown below:
     -   Allowed values: one Of (`on`, `off`, `low`, `bootingUp`)
     -   Optional
 
+-   `refDevice` : Reference to the device(s) used to monitor this streetligth.
+
+    -   Attribute type: List of Reference to entity(ies) of type [Device](../Device/Device/doc/spec.md)
+    -   Optional
+
 -   `refStreetlightGroup` : Streetlight's group, if this streetlight belongs to
     any group.
 

--- a/specs/StreetLighting/Streetlight/example.json
+++ b/specs/StreetLighting/Streetlight/example.json
@@ -1,0 +1,18 @@
+{
+  "id": "streetlight:guadalajara:4567",
+  "type": "Streetlight",
+  "location": {
+    "type": "Point",
+    "coordinates": [  -3.164485591715449, 40.62785133667262 ]
+  },
+  "areaServed": "Roundabouts city entrance",
+  "status": "ok",
+  "refStreetlightGroup": "streetlightgroup:G345",
+  "refStreetlightModel": "streetlightmodel:STEEL_Tubular_10m",
+  "circuit": "C-456-A467",
+  "lanternHeight": 10,
+  "locationCategory" : "centralIsland",
+  "powerState": "off",
+  "controllingMethod": "individual",
+  "dateLastLampChange": "2016-07-08T08:02:21.753Z"
+}

--- a/specs/StreetLighting/Streetlight/schema.json
+++ b/specs/StreetLighting/Streetlight/schema.json
@@ -113,7 +113,7 @@
         "locationCategory": {
           "type": "string",
           "enum": [
-            "facade",
+            "façade",
             "sidewalk",
             "pedestrianPath",
             "road",

--- a/specs/StreetLighting/Streetlight/schema.json
+++ b/specs/StreetLighting/Streetlight/schema.json
@@ -14,16 +14,13 @@
           "type": "string",
           "enum": [
             "Streetlight"
-          ],
-          "description": "NGSI Entity type"
+          ]
         },
         "areaServed": {
-          "type": "string",
-          "description": "Higher level area to which this streetlight belongs to. It can be used to group streetlights per responsible, district, neighbourhood, etc."
+          "type": "string"
         },
         "circuit": {
-          "type": "string",
-          "description": "The circuit to which this streetlight connects to and gets power from. Typically it will contain an identifier that will allow to obtain more information about such circuit."
+          "type": "string"
         },
         "refStreetlightModel": {
           "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
@@ -38,8 +35,7 @@
             "defectiveLamp",
             "columnIssue",
             "brokenLantern"
-          ],
-          "description": "The overall status of this street light"
+          ]
         },
         "powerState": {
             "type": "string",
@@ -48,67 +44,56 @@
                 "off",
                 "low",
                 "bootingUp"
-            ],
-            "description": "Streetlight's power state."
+            ]
         },
         "refDevice": {
           "type": "array",
           "items": { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType" },
           "minItems": 1,
-          "uniqueItems": true,
-          "description": "Reference to the device(s) used to monitor this streetligth"
+          "uniqueItems": true
         },
         "refStreetlightGroup": {
           "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
         },
         "dateLastLampChange": {
           "type": "string",
-          "format": "date-time",
-          "description": "Timestamp of the last change of lamp made. If `null` it will mean that the lamp has never been changed."
+          "format": "date-time"
         },
         "dateLastSwitchingOn": {
           "type": "string",
-          "format": "date-time",
-          "description": "Timestamp of the last switching on."
+          "format": "date-time"
         },
         "dateLastSwitchingOff": {
           "type": "string",
-          "format": "date-time",
-          "description": "Timestamp of the last switching off."
+          "format": "date-time"
         },
         "controllingMethod": {
           "type": "string",
           "enum": [
             "group",
             "individual"
-          ],
-          "description": "The method used to control this streetlight."
+          ]
         },
         "dateModified": {
           "type": "string",
-          "format": "date-time",
-          "description": "Timestamp of the last update made to this entity."
+          "format": "date-time"
         },
         "dateServiceStarted": {
           "type": "string",
-          "format": "date-time",
-          "description": "Date at which the streetlight started giving service."
+          "format": "date-time"
         },
         "image": {
           "type": "string",
-          "format": "uri",
-          "description": "A URL containing a photo of the streetlight."
+          "format": "uri"
         },
         "description": {
-          "type": "string",
-          "description": "Description about the streetlight."
+          "type": "string"
         },
         "annotations": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A field reserved for annotations (incidences, remarks, etc.)"
+          }
         },
         "locationCategory": {
           "type": "string",
@@ -124,19 +109,16 @@
             "tunnel",
             "parking",
             "centralIsland"
-          ],
-          "description": "Category of the location where the streetlight is placed."
+          ]
         },
         "laternHeight": {
           "type": "number",
-          "description": "Lantern's height. In columns with many arms this can vary between streetlights. Another variation source of this property are wall-mounted streetlights.",
           "minimum": 0
         },
         "illuminanceLevel": {
           "type": "number",
           "minimum": 0,
-          "maximum": 1,
-          "description": "Relative illuminance level setting."
+          "maximum": 1
         }
       }
     }

--- a/specs/StreetLighting/Streetlight/schema.json
+++ b/specs/StreetLighting/Streetlight/schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "https://fiware.github.io/dataModels/specs/StreetLighting/Streetlight/schema.json",
+  "title": "FIWARE - Street Lighting / Streetlight",
+  "description": "A Street light",
+  "type": "object",
+  "allOf": [
+    { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/GSMA-Commons" },
+    { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/Location-Commons" },
+    { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/PhysicalObject-Commons" },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Streetlight"
+          ],
+          "description": "NGSI Entity type"
+        },
+        "areaServed": {
+          "type": "string",
+          "description": "Higher level area to which this streetlight belongs to. It can be used to group streetlights per responsible, district, neighbourhood, etc."
+        },
+        "circuit": {
+          "type": "string",
+          "description": "The circuit to which this streetlight connects to and gets power from. Typically it will contain an identifier that will allow to obtain more information about such circuit."
+        },
+        "refStreetlightModel": {
+          "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
+        },
+        "refStreetlightControlCabinet": {
+          "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "ok",
+            "defectiveLamp",
+            "columnIssue",
+            "brokenLantern"
+          ],
+          "description": "The overall status of this street light"
+        },
+        "powerState": {
+            "type": "string",
+            "enum": [
+                "on",
+                "off",
+                "low",
+                "bootingUp"
+            ],
+            "description": "Streetlight's power state."
+        },
+        "refDevice": {
+          "type": "array",
+          "items": { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType" },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Reference to the device(s) used to monitor this streetligth"
+        },
+        "refStreetlightGroup": {
+          "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
+        },
+        "dateLastLampChange": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last change of lamp made. If `null` it will mean that the lamp has never been changed."
+        },
+        "dateLastSwitchingOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last switching on."
+        },
+        "dateLastSwitchingOff": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last switching off."
+        },
+        "controllingMethod": {
+          "type": "string",
+          "enum": [
+            "group",
+            "individual"
+          ],
+          "description": "The method used to control this streetlight."
+        },
+        "dateModified": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last update made to this entity."
+        },
+        "dateServiceStarted": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date at which the streetlight started giving service."
+        },
+        "image": {
+          "type": "string",
+          "format": "uri",
+          "description": "A URL containing a photo of the streetlight."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description about the streetlight."
+        },
+        "annotations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A field reserved for annotations (incidences, remarks, etc.)"
+        },
+        "locationCategory": {
+          "type": "string",
+          "enum": [
+            "facade",
+            "sidewalk",
+            "pedestrianPath",
+            "road",
+            "playground",
+            "park",
+            "garden",
+            "bridge",
+            "tunnel",
+            "parking",
+            "centralIsland"
+          ],
+          "description": "Category of the location where the streetlight is placed."
+        },
+        "laternHeight": {
+          "type": "number",
+          "description": "Lantern's height. In columns with many arms this can vary between streetlights. Another variation source of this property are wall-mounted streetlights.",
+          "minimum": 0
+        },
+        "illuminanceLevel": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Relative illuminance level setting."
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "type",
+    "location",
+    "status"
+  ]
+}

--- a/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -311,7 +311,7 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
       "dateLastProgramming": "2016-07-08",
       "maximumPowerAvailable": 10,
       "energyConsumed": 162456,
-      "dateMeteringStarted": "2013-07-07",
+      "dateMeteringStarted": "2013-07-07T15:05:59.408Z",
       "lastMeterReading": 161237,
       "meterReadingPeriod": 60,
       "intensity": {
@@ -323,7 +323,8 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
         "R": 45,
         "S": 43.5,
         "T": 42
-      }
+      },
+      "workingMode": "automatic"
     }
 
 ## Test it with a real service

--- a/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -100,13 +100,13 @@ The data model is defined as shown below:
 -   `dateServiceStarted` : Date at which the cabinet controller started giving
     service.
 
-    -   Attribute Type: [Date](http://schema.org/Date)
+    -   Attribute Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
 -   `dateLastProgramming` : Date at which there was a programming operation over
     the cabinet.
 
-    -   Attribute Type: [Date](http://schema.org/DateTime)
+    -   Attribute Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
 -   `nextActuationDeadline` : Deadline for next actuation to be performed
@@ -308,7 +308,7 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
       "modelName": "Simatic S7 1200",
       "refStreetlightGroup": ["streetlightgroup:BG678", "streetlightgroup:789"],
       "compliantWith": ["IP54"],
-      "dateLastProgramming": "2016-07-08",
+      "dateLastProgramming": "2016-07-08T16:04:30.201Z",
       "maximumPowerAvailable": 10,
       "energyConsumed": 162456,
       "dateMeteringStarted": "2013-07-07T15:05:59.408Z",

--- a/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -87,7 +87,7 @@ The data model is defined as shown below:
     -   Attribute type: List of [Text](https://schema.org/Text)
     -   Optional
 
--   `refDevice` : Reference to the device(s) used to monitor this streetligth.
+-   `refDevice` : Reference to the device(s) used to monitor this control cabinet.
 
     -   Attribute type: List of Reference to entity(ies) of type [Device](../Device/Device/doc/spec.md)
     -   Optional

--- a/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -87,6 +87,11 @@ The data model is defined as shown below:
     -   Attribute type: List of [Text](https://schema.org/Text)
     -   Optional
 
+-   `refDevice` : Reference to the device(s) used to monitor this streetligth.
+
+    -   Attribute type: List of Reference to entity(ies) of type [Device](../Device/Device/doc/spec.md)
+    -   Optional
+
 -   `dateModified` : Last update timestamp of this entity.
 
     -   Attribute type: [DateTime](https://schema.org/DateTime)

--- a/specs/StreetLighting/StreetlightControlCabinet/example.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/example.json
@@ -1,0 +1,30 @@
+{
+  "id": "streetlightcontrolcabinet:A45HGJK",
+  "type": "StreetlightControlCabinet",
+  "location": {
+    "type": "Point",
+    "coordinates": [  -3.164485591715449, 40.62785133667262 ]
+  },
+  "cupboardMadeOf": "plastic",
+  "brandName": "Siemens",
+  "modelName": "Simatic S7 1200",
+  "refStreetlightGroup": ["streetlightgroup:BG678", "streetlightgroup:789"],
+  "compliantWith": ["IP54"],
+  "dateLastProgramming": "2016-07-08",
+  "maximumPowerAvailable": 10,
+  "energyConsumed": 162456,
+  "dateMeteringStarted": "2013-07-07T15:05:59.408Z",
+  "lastMeterReading": 161237,
+  "meterReadingPeriod": 60,
+  "intensity": {
+     "R": 20.1,
+     "S": 14.4,
+     "T": 22
+  },
+  "reactivePower": {
+    "R": 45,
+    "S": 43.5,
+    "T": 42
+  },
+  "workingMode": "automatic"
+}

--- a/specs/StreetLighting/StreetlightControlCabinet/example.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/example.json
@@ -10,7 +10,7 @@
   "modelName": "Simatic S7 1200",
   "refStreetlightGroup": ["streetlightgroup:BG678", "streetlightgroup:789"],
   "compliantWith": ["IP54"],
-  "dateLastProgramming": "2016-07-08",
+  "dateLastProgramming": "2016-07-08T16:04:30.201Z",
   "maximumPowerAvailable": 10,
   "energyConsumed": 162456,
   "dateMeteringStarted": "2013-07-07T15:05:59.408Z",

--- a/specs/StreetLighting/StreetlightControlCabinet/schema.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/schema.json
@@ -1,0 +1,285 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "https://fiware.github.io/dataModels/specs/StreetLighting/StreetlightControlCabinet/schema.json",
+  "title": "FIWARE - Street Lighting / Streetlight Control Cabinet",
+  "description": "A Streetlight control cabinet",
+  "type": "object",
+  "allOf": [
+    { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/GSMA-Commons" },
+    { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/Location-Commons" },
+    { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/PhysicalObject-Commons" },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "StreetlightControlCabinet"
+          ],
+          "description": "NGSI Entity type"
+        },
+        "areaServed": {
+          "type": "string",
+          "description": "Higher level area to which this streetlight belongs to. It can be used to group streetlights per responsible, district, neighbourhood, etc."
+        },
+        "serialNumber": {
+          "type": "string",
+          "description": "Serial number of the control cabinet."
+        },
+        "refStreetlightGroup": {
+          "type": "array",
+          "items": {
+              "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType" },
+          "description": "Streetlight group(s) controlled."
+        },
+        "brandName": {
+          "type": "string",
+          "description": "Name of the cabinet's brand."
+        },
+        "modelName": {
+          "type": "string",
+          "description": "Name of the cabinet's model."
+        },
+        "manufacturerName": {
+          "type": "string",
+          "description": "Name of the cabinet's manufacturer."
+        },
+        "cupboardMadeOf": {
+          "type": "string",
+          "enum": [
+            "plastic",
+            "metal",
+            "concrete",
+            "other"
+          ],
+          "description": "Material the cabinet's cupboard is made of."
+        },
+        "features": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "astronomicalClock",
+              "individualControl"
+            ]
+          },
+          "minItems": 0,
+          "uniqueItems": true,
+          "description": "A list of cabinet controller features."
+        },
+        "compliantWith": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of standards to which the cabinet controller is compliant with (ex. `IP54`)"
+        },
+        "annotations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A field reserved for annotations (incidences, remarks, etc.)"
+        },
+        "refDevice": {
+          "type": "array",
+          "items": { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType" },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Reference to the device(s) used to monitor this streetligth"
+        },
+        "dateModified": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last update made to this entity."
+        },
+        "dateServiceStarted": {
+          "type": "string",
+          "format": "date",
+          "description": "Date at which the streetlight started giving service."
+        },
+        "dateLastProgramming": {
+          "type": "string",
+          "format": "date",
+          "description": "Date at which there was a programming operation over the cabinet."
+        },
+        "nextActuationDeadline": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Deadline for next actuation to be performed (programming, testing, etc.)."
+        },
+        "responsible": {
+          "type": "string",
+          "description": "Responsible for the cabinet controller, i.e. entity in charge of actuating (programming, etc.)."
+        },
+        "workingMode": {
+          "type": "string",
+          "enum": [
+            "automatic",
+            "manual",
+            "semiautomatic"
+          ],
+          "description": "The method used to control this streetlight."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description about the streetlight."
+        },
+        "maximumPowerAvailable": {
+          "type": "number",
+          "items": {
+            "type": "string"
+          },
+          "description": "The maximum power available (by contract) for the circuits controlled by this cabinet."
+        },
+        "energyConsumed": {
+          "type": "number",
+          "description": "Energy consumed by the circuits controlled since metering started (since `dateMeteringStarted`)",
+          "minimum": 0
+        },
+        "energyCost": {
+          "type": "number",
+          "description": "Cost of the energy consumed by the circuits controlled since the metering start date (`dateMeteringStarted`)"
+        },
+        "reactiveEnergyConsumed": {
+          "type": "number",
+          "description": "Energy consumed (with regards to reactive power) by circuits since the metering start date (`dateMeteringStarted`).",
+          "minimum": 0
+        },
+        "dateMeteringStarted": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The starting date for metering energy consumed."
+        },
+        "lastMeterReading": {
+          "type": "number",
+          "description": "Value of the last reading obtained from the energy consumed metering system."
+        },
+        "meterReadingPeriod": {
+          "type": "number",
+          "description": "The periodicity of energy consumed meter readings in days."
+        },
+        "frequency": {
+          "type": "number",
+          "description": "The working frequency of the circuit."
+        },
+        "totalActivePower": {
+          "type": "number",
+          "description": "Active power currently consumed (counting all phases)."
+        },
+        "totalReactivePower": {
+          "type": "number",
+          "description": "Reactive power currently consumed (counting all phases)."
+        },
+        "activePower": {
+          "type": "object",
+          "properties": {
+            "R": {
+              "type": "number"
+            },
+            "S": {
+              "type": "number"
+            },
+            "T": {
+              "type": "number"
+            }
+          },
+          "description": "Active power consumed  per phase. The actual values will be conveyed by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T."
+        },
+        "reactivePower": {
+          "type": "object",
+          "properties": {
+            "R": {
+              "type": "number"
+            },
+            "S": {
+              "type": "number"
+            },
+            "T": {
+              "type": "number"
+            }
+          },
+          "description": "Reactive power. The actual values will be conveyed by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T."
+        },
+        "powerFactor": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1,
+          "description": "Power factor."
+        },
+        "cosPhi": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1,
+          "description": "\"Cosin of phi\" parameter."
+        },
+        "intensity": {
+          "type": "object",
+          "properties": {
+            "R": {
+              "type": "number"
+            },
+            "S": {
+              "type": "number"
+            },
+            "T": {
+              "type": "number"
+            }
+          },
+          "description": "Electric intensity. The actual values will be conveyed by one subproperty per alternating current phase.  The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+        },
+        "voltage": {
+          "type": "object",
+          "properties": {
+            "R": {
+              "type": "number"
+            },
+            "S": {
+              "type": "number"
+            },
+            "T": {
+              "type": "number"
+            }
+          },
+          "description": "Electric tension. The actual values will be conveyed by one subproperty alternating current phase.  The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+        },
+        "thdrVoltage": {
+          "type": "object",
+          "properties": {
+            "R": {
+              "type": "number"
+            },
+            "S": {
+              "type": "number"
+            },
+            "T": {
+              "type": "number"
+            }
+          },
+          "description": "Total harmonic distortion (R) of The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+        },
+        "thdrIntensity": {
+          "type": "object",
+          "properties": {
+            "R": {
+              "type": "number"
+            },
+            "S": {
+              "type": "number"
+            },
+            "T": {
+              "type": "number"
+            }
+          },
+          "description": "Total harmonic distortion (R) of intensity. The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "type",
+    "location",
+    "refStreetlightGroup",
+    "workingMode"
+  ]
+}

--- a/specs/StreetLighting/StreetlightControlCabinet/schema.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/schema.json
@@ -86,11 +86,11 @@
         },
         "dateServiceStarted": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "dateLastProgramming": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "nextActuationDeadline": {
           "type": "string",

--- a/specs/StreetLighting/StreetlightControlCabinet/schema.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/schema.json
@@ -14,16 +14,13 @@
           "type": "string",
           "enum": [
             "StreetlightControlCabinet"
-          ],
-          "description": "NGSI Entity type"
+          ]
         },
         "areaServed": {
-          "type": "string",
-          "description": "Higher level area to which this streetlight belongs to. It can be used to group streetlights per responsible, district, neighbourhood, etc."
+          "type": "string"
         },
         "serialNumber": {
-          "type": "string",
-          "description": "Serial number of the control cabinet."
+          "type": "string"
         },
         "refStreetlightGroup": {
           "type": "array",
@@ -31,20 +28,16 @@
             "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
           },
           "minItems": 1,
-          "uniqueItems": true,
-          "description": "Streetlight group(s) controlled."
+          "uniqueItems": true
         },
         "brandName": {
-          "type": "string",
-          "description": "Name of the cabinet's brand."
+          "type": "string"
         },
         "modelName": {
-          "type": "string",
-          "description": "Name of the cabinet's model."
+          "type": "string"
         },
         "manufacturerName": {
-          "type": "string",
-          "description": "Name of the cabinet's manufacturer."
+          "type": "string"
         },
         "cupboardMadeOf": {
           "type": "string",
@@ -53,8 +46,7 @@
             "metal",
             "concrete",
             "other"
-          ],
-          "description": "Material the cabinet's cupboard is made of."
+          ]
         },
         "features": {
           "type": "array",
@@ -66,8 +58,7 @@
             ]
           },
           "minItems": 1,
-          "uniqueItems": true,
-          "description": "A list of cabinet controller features."
+          "uniqueItems": true
         },
         "compliantWith": {
           "type": "array",
@@ -75,46 +66,38 @@
             "type": "string"
           },
           "minItems": 1,
-          "uniqueItems": true,
-          "description": "A list of standards to which the cabinet controller is compliant with (ex. `IP54`)"
+          "uniqueItems": true
         },
         "annotations": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A field reserved for annotations (incidences, remarks, etc.)"
+          }
         },
         "refDevice": {
           "type": "array",
           "items": { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType" },
           "minItems": 1,
-          "uniqueItems": true,
-          "description": "Reference to the device(s) used to monitor this streetligth"
+          "uniqueItems": true
         },
         "dateModified": {
           "type": "string",
-          "format": "date-time",
-          "description": "Timestamp of the last update made to this entity."
+          "format": "date-time"
         },
         "dateServiceStarted": {
           "type": "string",
-          "format": "date",
-          "description": "Date at which the streetlight started giving service."
+          "format": "date"
         },
         "dateLastProgramming": {
           "type": "string",
-          "format": "date",
-          "description": "Date at which there was a programming operation over the cabinet."
+          "format": "date"
         },
         "nextActuationDeadline": {
           "type": "string",
-          "format": "date-time",
-          "description": "Deadline for next actuation to be performed (programming, testing, etc.)."
+          "format": "date-time"
         },
         "responsible": {
-          "type": "string",
-          "description": "Responsible for the cabinet controller, i.e. entity in charge of actuating (programming, etc.)."
+          "type": "string"
         },
         "workingMode": {
           "type": "string",
@@ -122,61 +105,49 @@
             "automatic",
             "manual",
             "semiautomatic"
-          ],
-          "description": "The method used to control this streetlight."
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "Description about the streetlight."
+          "type": "string"
         },
         "maximumPowerAvailable": {
           "type": "number",
-          "minimum": 0,
-          "description": "The maximum power available (by contract) for the circuits controlled by this cabinet."
+          "minimum": 0
         },
         "energyConsumed": {
           "type": "number",
-          "description": "Energy consumed by the circuits controlled since metering started (since `dateMeteringStarted`)",
           "minimum": 0
         },
         "energyCost": {
           "type": "number",
-          "description": "Cost of the energy consumed by the circuits controlled since the metering start date (`dateMeteringStarted`)",
           "minimum": 0
         },
         "reactiveEnergyConsumed": {
           "type": "number",
-          "description": "Energy consumed (with regards to reactive power) by circuits since the metering start date (`dateMeteringStarted`).",
           "minimum": 0
         },
         "dateMeteringStarted": {
           "type": "string",
-          "format": "date-time",
-          "description": "The starting date for metering energy consumed."
+          "format": "date-time"
         },
         "lastMeterReading": {
           "type": "number",
-          "description": "Value of the last reading obtained from the energy consumed metering system.",
           "minimum": 0
         },
         "meterReadingPeriod": {
           "type": "number",
-          "description": "The periodicity of energy consumed meter readings in days.",
           "minimum": 0
         },
         "frequency": {
           "type": "number",
-          "description": "The working frequency of the circuit.",
           "minimum": 0
         },
         "totalActivePower": {
           "type": "number",
-          "description": "Active power currently consumed (counting all phases).",
           "minimum": 0
         },
         "totalReactivePower": {
           "type": "number",
-          "description": "Reactive power currently consumed (counting all phases).",
           "minimum": 0
         },
         "activePower": {
@@ -194,8 +165,7 @@
               "type": "number",
               "minimum": 0
             }
-          },
-          "description": "Active power consumed per phase. The actual values will be conveyed by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T."
+          }
         },
         "reactivePower": {
           "type": "object",
@@ -212,20 +182,17 @@
               "type": "number",
               "minimum": 0
             }
-          },
-          "description": "Reactive power. The actual values will be conveyed by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T."
+          }
         },
         "powerFactor": {
           "type": "number",
           "minimum": -1,
-          "maximum": 1,
-          "description": "Power factor."
+          "maximum": 1
         },
         "cosPhi": {
           "type": "number",
           "minimum": -1,
-          "maximum": 1,
-          "description": "\"Cosin of phi\" parameter."
+          "maximum": 1
         },
         "intensity": {
           "type": "object",
@@ -242,8 +209,7 @@
               "type": "number",
               "minimum": 0
             }
-          },
-          "description": "Electric intensity. The actual values will be conveyed by one subproperty per alternating current phase.  The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+          }
         },
         "voltage": {
           "type": "object",
@@ -260,8 +226,7 @@
               "type": "number",
               "minimum": 0
             }
-          },
-          "description": "Electric tension. The actual values will be conveyed by one subproperty alternating current phase.  The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+          }
         },
         "thdrVoltage": {
           "type": "object",
@@ -278,8 +243,7 @@
               "type": "number",
               "minimum": 0
             }
-          },
-          "description": "Total harmonic distortion (R) of The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+          }
         },
         "thdrIntensity": {
           "type": "object",
@@ -296,8 +260,7 @@
               "type": "number",
               "minimum": 0
             }
-          },
-          "description": "Total harmonic distortion (R) of intensity. The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
+          }
         }
       }
     }

--- a/specs/StreetLighting/StreetlightControlCabinet/schema.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/schema.json
@@ -28,7 +28,10 @@
         "refStreetlightGroup": {
           "type": "array",
           "items": {
-              "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType" },
+            "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType"
+          },
+          "minItems": 1,
+          "uniqueItems": true,
           "description": "Streetlight group(s) controlled."
         },
         "brandName": {
@@ -62,7 +65,7 @@
               "individualControl"
             ]
           },
-          "minItems": 0,
+          "minItems": 1,
           "uniqueItems": true,
           "description": "A list of cabinet controller features."
         },
@@ -71,6 +74,8 @@
           "items": {
             "type": "string"
           },
+          "minItems": 1,
+          "uniqueItems": true,
           "description": "A list of standards to which the cabinet controller is compliant with (ex. `IP54`)"
         },
         "annotations": {
@@ -126,9 +131,7 @@
         },
         "maximumPowerAvailable": {
           "type": "number",
-          "items": {
-            "type": "string"
-          },
+          "minimum": 0,
           "description": "The maximum power available (by contract) for the circuits controlled by this cabinet."
         },
         "energyConsumed": {
@@ -138,7 +141,8 @@
         },
         "energyCost": {
           "type": "number",
-          "description": "Cost of the energy consumed by the circuits controlled since the metering start date (`dateMeteringStarted`)"
+          "description": "Cost of the energy consumed by the circuits controlled since the metering start date (`dateMeteringStarted`)",
+          "minimum": 0
         },
         "reactiveEnergyConsumed": {
           "type": "number",
@@ -152,50 +156,61 @@
         },
         "lastMeterReading": {
           "type": "number",
-          "description": "Value of the last reading obtained from the energy consumed metering system."
+          "description": "Value of the last reading obtained from the energy consumed metering system.",
+          "minimum": 0
         },
         "meterReadingPeriod": {
           "type": "number",
-          "description": "The periodicity of energy consumed meter readings in days."
+          "description": "The periodicity of energy consumed meter readings in days.",
+          "minimum": 0
         },
         "frequency": {
           "type": "number",
-          "description": "The working frequency of the circuit."
+          "description": "The working frequency of the circuit.",
+          "minimum": 0
         },
         "totalActivePower": {
           "type": "number",
-          "description": "Active power currently consumed (counting all phases)."
+          "description": "Active power currently consumed (counting all phases).",
+          "minimum": 0
         },
         "totalReactivePower": {
           "type": "number",
-          "description": "Reactive power currently consumed (counting all phases)."
+          "description": "Reactive power currently consumed (counting all phases).",
+          "minimum": 0
         },
         "activePower": {
           "type": "object",
           "properties": {
             "R": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "S": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "T": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             }
           },
-          "description": "Active power consumed  per phase. The actual values will be conveyed by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T."
+          "description": "Active power consumed per phase. The actual values will be conveyed by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T."
         },
         "reactivePower": {
           "type": "object",
           "properties": {
             "R": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "S": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "T": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             }
           },
           "description": "Reactive power. The actual values will be conveyed by subproperties which name will be equal to the name of each of the alternating current phases, typically R, S, T."
@@ -216,13 +231,16 @@
           "type": "object",
           "properties": {
             "R": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "S": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "T": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             }
           },
           "description": "Electric intensity. The actual values will be conveyed by one subproperty per alternating current phase.  The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
@@ -231,13 +249,16 @@
           "type": "object",
           "properties": {
             "R": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "S": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "T": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             }
           },
           "description": "Electric tension. The actual values will be conveyed by one subproperty alternating current phase.  The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
@@ -246,13 +267,16 @@
           "type": "object",
           "properties": {
             "R": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "S": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "T": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             }
           },
           "description": "Total harmonic distortion (R) of The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."
@@ -261,13 +285,16 @@
           "type": "object",
           "properties": {
             "R": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "S": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             },
             "T": {
-              "type": "number"
+              "type": "number",
+              "minimum": 0
             }
           },
           "description": "Total harmonic distortion (R) of intensity. The name of each subproperty will be equal to a phase mnemonic. The mnemonic used for denoting phases can vary depending on world regions. In Europe they are typically named as `R`, `S`, `T`."


### PR DESCRIPTION
This PR adds a `refDevice` attribute to the `Streetlight` and to the `StreetlightControlCabinet` data models. This attribute works in the same way in the [`WasterContainer` data model](https://github.com/Fiware/dataModels/blob/master/specs/WasteManagement/WasteContainer/doc/spec.md).

As there is not schema file for those datamodels, this PR also add an initial version of the schema for those datamodels.