### PR TITLE
Update link StreetlightGroup

### DIFF
--- a/specs/StreetLighting/doc/introduction.md
+++ b/specs/StreetLighting/doc/introduction.md
@@ -10,7 +10,7 @@ It encompasses the following entity types:
 -   [Streetlight](../Streetlight/doc/spec.md). It represents a particular
     instance of a streetlight. A streetlight is composed by a lantern and a
     lamp. Such elements are mounted on a column (pole), wall or other structure.
--   [StreetlightGroup](../Streetlight/doc/spec.md). It represents a group of
+-   [StreetlightGroup](../StreetlightGroup/doc/spec.md). It represents a group of
     streetlights being part of the same circuit and controlled together by an
     automated system.
 -   [StreetlightModel](../StreetlightModel/doc/spec.md). It represents a model


### PR DESCRIPTION
Link of StreetlightGroup is changen to "../StreetlightGroup/doc/spec.md". Because he was going  to "../Streetlight/doc/spec.md".
In the "https://fiware-datamodels.readthedocs.io/en/latest/StreetLighting/doc/introduction/index.html" I saw this issue