### PR TITLE
Add lint:md and lint:text to travis

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,0 +1,5 @@
+exports.settings = {bullet: '-', paddedTable: true}
+
+exports.plugins = [
+  require('./validator/node_modules/remark-preset-lint-recommended')
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
         - docker run -d --name orion1 --link mongodb:mongodb -p 1026:1026 fiware/orion -dbhost mongodb
       before_script:
         - npm run lint -C ./validator
+        - npm run lint:md -C ./validator
+        - npm run lint:text -C ./validator
         - node ./validator/validate.js -i common-schema.json -i geometry-schema.json -i specs/Weather/weather-schema.json -i specs/Alert/alert-schema.json -p specs -c true
         - npm test -C ./validator
       script:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ these schemas the
 [AJV JSON Schema Validator](https://github.com/epoberezkin/ajv) is being used.
 For using it just install it through npm:
 
-```
+```console
     npm install ajv
     npm install ajv-cli
 ```

--- a/specs/AgriFood/README.md
+++ b/specs/AgriFood/README.md
@@ -1,18 +1,18 @@
-# Agrifood Data Models 
+# Agrifood Data Models
 
-This folder is intended to contain data models for Smart Agri Food. 
+This folder is intended to contain data models for Smart Agri Food.
 
-The initial Data Models have been created by the GSMA IoT Big Data Project and are:
+The initial Data Models have been created by the GSMA IoT Big Data Project and
+are:
 
-* [AgriCrop](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Crop.md)
-* [AgriGreenhouse](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Greenhouse.md)
-* [AgriParcelOperation](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Parcel-Operation.md)
-* [AgriParcelRecord](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Parcel-Record.md)
-* [AgriParcel](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Parcel.md)
-* [AgriPest](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Pest.md)
-* [AgriProductType](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Product-Type.md)
+-   [AgriCrop](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Crop.md)
+-   [AgriGreenhouse](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Greenhouse.md)
+-   [AgriParcelOperation](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Parcel-Operation.md)
+-   [AgriParcelRecord](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Parcel-Record.md)
+-   [AgriParcel](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Parcel.md)
+-   [AgriPest](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Pest.md)
+-   [AgriProductType](https://github.com/GSMADeveloper/NGSI-LD-Entities/blob/master/definitions/Agri-Product-Type.md)
 
-* [WeatherObserved](../Weather/WeatherObserved/doc/spec.md)
-* [WeatherForecast](../Weather/WeatherForecast/doc/spec.md)
-* [WeatherAlert](../Weather/WeatherAlert/doc/spec.md)
-
+-   [WeatherObserved](../Weather/WeatherObserved/doc/spec.md)
+-   [WeatherForecast](../Weather/WeatherForecast/doc/spec.md)
+-   [WeatherAlert](../Weather/WeatherAlert/doc/spec.md)

--- a/specs/Alert/README.md
+++ b/specs/Alert/README.md
@@ -23,22 +23,19 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```json
 {
-  "id": "Alert:1",
-  "type": "Alert",
-  "category": "traffic",
-  "subCategory": "trafficJam",
-  "severity": "high",
-  "location": {
-    "type": "Point",
-    "coordinates": [
-      -3.712247222222222,
-      40.423852777777775
-    ]
-  },
-  "dateIssued": "2017-01-02T09:25:55.00Z",
-  "description": "The road is completely blocked for 3kms",
-  "alertSource": "https://account.lab.fiware.org/users/8"
+    "id": "Alert:1",
+    "type": "Alert",
+    "category": "traffic",
+    "subCategory": "trafficJam",
+    "severity": "high",
+    "location": {
+        "type": "Point",
+        "coordinates": [-3.712247222222222, 40.423852777777775]
+    },
+    "dateIssued": "2017-01-02T09:25:55.00Z",
+    "description": "The road is completely blocked for 3kms",
+    "alertSource": "https://account.lab.fiware.org/users/8"
 }
 ```

--- a/specs/Building/Building/README.md
+++ b/specs/Building/Building/README.md
@@ -11,123 +11,73 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```json
 {
-  "id": "building-a85e3da145c1",
-  "type": "Building",
-  "dateCreated": "2016-08-08T10:18:16Z",
-  "dateModified": "2016-08-08T10:18:16Z",
-  "source": "http://www.example.com",
-  "dataProvider": "OperatorA",
-  "category": [
-    "office"
-  ],
-  "containedInPlace": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          100,
-          0
-        ],
-        [
-          101,
-          0
-        ],
-        [
-          101,
-          1
-        ],
-        [
-          100,
-          1
-        ],
-        [
-          100,
-          0
-        ]
-      ]
+    "id": "building-a85e3da145c1",
+    "type": "Building",
+    "dateCreated": "2016-08-08T10:18:16Z",
+    "dateModified": "2016-08-08T10:18:16Z",
+    "source": "http://www.example.com",
+    "dataProvider": "OperatorA",
+    "category": ["office"],
+    "containedInPlace": {
+        "type": "Polygon",
+        "coordinates": [[[100, 0], [101, 0], [101, 1], [100, 1], [100, 0]]]
+    },
+    "location": {
+        "type": "Polygon",
+        "coordinates": [[[100, 0], [101, 0], [101, 1], [100, 1], [100, 0]]]
+    },
+    "address": {
+        "addressLocality": "London",
+        "postalCode": "EC4N 8AF",
+        "streetAddress": "25 Walbrook"
+    },
+    "owner": [
+        "cdfd9cb8-ae2b-47cb-a43a-b9767ffd5c84",
+        "1be9cd61-ef59-421f-a326-4b6c84411ad4"
+    ],
+    "occupier": ["9830f692-7677-11e6-838b-4f9fb3dc5a4f"],
+    "floorsAboveGround": 7,
+    "floorsBelowGround": 0,
+    "description": "Office block",
+    "mapUrl": "http://www.example.com",
+    "openingHours": [
+        {
+            "closes": "17:00:00",
+            "dayOfWeek": "http://schema.org/Sunday",
+            "opens": "09:00:00"
+        },
+        {
+            "closes": "17:00:00",
+            "dayOfWeek": "http://schema.org/Saturday",
+            "opens": "09:00:00"
+        },
+        {
+            "closes": "17:00:00",
+            "dayOfWeek": "http://schema.org/Thursday",
+            "opens": "09:00:00"
+        },
+        {
+            "closes": "17:00:00",
+            "dayOfWeek": "http://schema.org/Tuesday",
+            "opens": "09:00:00"
+        },
+        {
+            "closes": "17:00:00",
+            "dayOfWeek": "http://schema.org/Friday",
+            "opens": "09:00:00"
+        },
+        {
+            "closes": "17:00:00",
+            "dayOfWeek": "http://schema.org/Monday",
+            "opens": "09:00:00"
+        },
+        {
+            "closes": "17:00:00",
+            "dayOfWeek": "http://schema.org/Wednesday",
+            "opens": "09:00:00"
+        }
     ]
-  },
-  "location": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          100,
-          0
-        ],
-        [
-          101,
-          0
-        ],
-        [
-          101,
-          1
-        ],
-        [
-          100,
-          1
-        ],
-        [
-          100,
-          0
-        ]
-      ]
-    ]
-  },
-  "address": {
-    "addressLocality": "London",
-    "postalCode": "EC4N 8AF",
-    "streetAddress": "25 Walbrook"
-  },
-  "owner": [
-    "cdfd9cb8-ae2b-47cb-a43a-b9767ffd5c84",
-    "1be9cd61-ef59-421f-a326-4b6c84411ad4"
-  ],
-  "occupier": [
-    "9830f692-7677-11e6-838b-4f9fb3dc5a4f"
-  ],
-  "floorsAboveGround": 7,
-  "floorsBelowGround": 0,
-  "description": "Office block",
-  "mapUrl": "http://www.example.com",
-  "openingHours": [
-    {
-      "closes": "17:00:00",
-      "dayOfWeek": "http://schema.org/Sunday",
-      "opens": "09:00:00"
-    },
-    {
-      "closes": "17:00:00",
-      "dayOfWeek": "http://schema.org/Saturday",
-      "opens": "09:00:00"
-    },
-    {
-      "closes": "17:00:00",
-      "dayOfWeek": "http://schema.org/Thursday",
-      "opens": "09:00:00"
-    },
-    {
-      "closes": "17:00:00",
-      "dayOfWeek": "http://schema.org/Tuesday",
-      "opens": "09:00:00"
-    },
-    {
-      "closes": "17:00:00",
-      "dayOfWeek": "http://schema.org/Friday",
-      "opens": "09:00:00"
-    },
-    {
-      "closes": "17:00:00",
-      "dayOfWeek": "http://schema.org/Monday",
-      "opens": "09:00:00"
-    },
-    {
-      "closes": "17:00:00",
-      "dayOfWeek": "http://schema.org/Wednesday",
-      "opens": "09:00:00"
-    }
-  ]
 }
 ```

--- a/specs/Building/Building/doc/spec.md
+++ b/specs/Building/Building/doc/spec.md
@@ -113,159 +113,108 @@ Normalized NGSI response
     "id": "building-a85e3da145c1",
     "type": "Building",
     "category": {
-        "value": [
-            "office"
-        ]
-    }, 
+        "value": ["office"]
+    },
     "floorsBelowGround": {
         "value": 0
-    }, 
+    },
     "description": {
         "value": "Office block"
-    }, 
+    },
     "floorsAboveGround": {
         "value": 7
-    }, 
+    },
     "occupier": {
         "type": "Relationship",
-        "value": [
-            "9830f692-7677-11e6-838b-4f9fb3dc5a4f"
-        ]
-    }, 
+        "value": ["9830f692-7677-11e6-838b-4f9fb3dc5a4f"]
+    },
     "mapUrl": {
         "type": "URL",
         "value": "http://www.example.com"
-    }, 
+    },
     "dateCreated": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-08-08T10:18:16Z"
-    }, 
+    },
     "source": {
         "value": "http://www.example.com"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Polygon", 
-            "coordinates": [
-                [
-                    [
-                        100, 
-                        0
-                    ], 
-                    [
-                        101, 
-                        0
-                    ], 
-                    [
-                        101, 
-                        1
-                    ], 
-                    [
-                        100, 
-                        1
-                    ], 
-                    [
-                        100, 
-                        0
-                    ]
-                ]
-            ]
+            "type": "Polygon",
+            "coordinates": [[[100, 0], [101, 0], [101, 1], [100, 1], [100, 0]]]
         }
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "London", 
-            "postalCode": "EC4N 8AF", 
+            "addressLocality": "London",
+            "postalCode": "EC4N 8AF",
             "streetAddress": "25 Walbrook"
         }
-    }, 
+    },
     "owner": {
         "type": "Relationship",
         "value": [
-            "cdfd9cb8-ae2b-47cb-a43a-b9767ffd5c84", 
+            "cdfd9cb8-ae2b-47cb-a43a-b9767ffd5c84",
             "1be9cd61-ef59-421f-a326-4b6c84411ad4"
         ]
-    }, 
+    },
     "openingHours": {
         "value": [
             {
-                "dayOfWeek": "http://schema.org/Sunday", 
-                "closes": "17:00:00", 
+                "dayOfWeek": "http://schema.org/Sunday",
+                "closes": "17:00:00",
                 "opens": "09:00:00"
-            }, 
+            },
             {
-                "dayOfWeek": "http://schema.org/Saturday", 
-                "closes": "17:00:00", 
+                "dayOfWeek": "http://schema.org/Saturday",
+                "closes": "17:00:00",
                 "opens": "09:00:00"
-            }, 
+            },
             {
-                "dayOfWeek": "http://schema.org/Thursday", 
-                "closes": "17:00:00", 
+                "dayOfWeek": "http://schema.org/Thursday",
+                "closes": "17:00:00",
                 "opens": "09:00:00"
-            }, 
+            },
             {
-                "dayOfWeek": "http://schema.org/Tuesday", 
-                "closes": "17:00:00", 
+                "dayOfWeek": "http://schema.org/Tuesday",
+                "closes": "17:00:00",
                 "opens": "09:00:00"
-            }, 
+            },
             {
-                "dayOfWeek": "http://schema.org/Friday", 
-                "closes": "17:00:00", 
+                "dayOfWeek": "http://schema.org/Friday",
+                "closes": "17:00:00",
                 "opens": "09:00:00"
-            }, 
+            },
             {
-                "dayOfWeek": "http://schema.org/Monday", 
-                "closes": "17:00:00", 
+                "dayOfWeek": "http://schema.org/Monday",
+                "closes": "17:00:00",
                 "opens": "09:00:00"
-            }, 
+            },
             {
-                "dayOfWeek": "http://schema.org/Wednesday", 
-                "closes": "17:00:00", 
+                "dayOfWeek": "http://schema.org/Wednesday",
+                "closes": "17:00:00",
                 "opens": "09:00:00"
             }
         ]
-    }, 
+    },
     "dataProvider": {
         "value": "OperatorA"
-    }, 
+    },
     "dateModified": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-08-08T10:18:16Z"
-    }, 
+    },
     "containedInPlace": {
         "value": {
-            "type": "Polygon", 
-            "coordinates": [
-                [
-                    [
-                        100, 
-                        0
-                    ], 
-                    [
-                        101, 
-                        0
-                    ], 
-                    [
-                        101, 
-                        1
-                    ], 
-                    [
-                        100, 
-                        1
-                    ], 
-                    [
-                        100, 
-                        0
-                    ]
-                ]
-            ]
+            "type": "Polygon",
+            "coordinates": [[[100, 0], [101, 0], [101, 1], [100, 1], [100, 0]]]
         }
     }
 }
 ```
-
 
 ### key-value pairs Example
 

--- a/specs/Building/BuildingOperation/README.md
+++ b/specs/Building/BuildingOperation/README.md
@@ -13,34 +13,31 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```json
 {
-  "id": "57b912ab-eb47-4cd5-bc9d-73abece1f1b3",
-  "type": "BuildingOperation",
-  "dateCreated": "2016-08-08T10:18:16Z",
-  "dateModified": "2016-08-08T10:18:16Z",
-  "source":  "http://www.example.com",
-  "dataProvider": "OperatorA",
-  "refBuilding": "building-a85e3da145c1",
-  "operationType": "airConditioning",
-  "description": "Air conditioning levels reduced due to out of hours",
-  "result": "ok",
-  "startDate": "2016-08-08T10:18:16Z",
-  "endDate": "2016-08-20T10:18:16Z",
-  "dateStarted": "2016-08-08T10:18:16Z",
-  "dateFinished": "2016-08-20T10:18:16Z",
-  "status": "finished",
-  "operationSequence": [
-   "fan_power=0",
-   "set_temperature=24"
-  ],
-  "refRelatedBuildingOperation": [
-    "b4fb8bff-1a8f-455f-8cc0-ca43c069f865",
-    "55c24793-3437-4157-9bda-667c9e1531fc"
-  ],
-  "refRelatedDeviceOperation": [
-    "36744245-6716-4a28-84c7-0e3d7520f143",
-    "33b2b713-9223-40a5-87a0-3f80a1264a6c"
-  ]
+    "id": "57b912ab-eb47-4cd5-bc9d-73abece1f1b3",
+    "type": "BuildingOperation",
+    "dateCreated": "2016-08-08T10:18:16Z",
+    "dateModified": "2016-08-08T10:18:16Z",
+    "source": "http://www.example.com",
+    "dataProvider": "OperatorA",
+    "refBuilding": "building-a85e3da145c1",
+    "operationType": "airConditioning",
+    "description": "Air conditioning levels reduced due to out of hours",
+    "result": "ok",
+    "startDate": "2016-08-08T10:18:16Z",
+    "endDate": "2016-08-20T10:18:16Z",
+    "dateStarted": "2016-08-08T10:18:16Z",
+    "dateFinished": "2016-08-20T10:18:16Z",
+    "status": "finished",
+    "operationSequence": ["fan_power=0", "set_temperature=24"],
+    "refRelatedBuildingOperation": [
+        "b4fb8bff-1a8f-455f-8cc0-ca43c069f865",
+        "55c24793-3437-4157-9bda-667c9e1531fc"
+    ],
+    "refRelatedDeviceOperation": [
+        "36744245-6716-4a28-84c7-0e3d7520f143",
+        "33b2b713-9223-40a5-87a0-3f80a1264a6c"
+    ]
 }
 ```

--- a/specs/Building/BuildingOperation/doc/spec.md
+++ b/specs/Building/BuildingOperation/doc/spec.md
@@ -117,65 +117,62 @@ Normalized NGSI response
     "type": "BuildingOperation",
     "status": {
         "value": "finished"
-    }, 
+    },
     "startDate": {
         "value": "2016-08-08T10:18:16Z"
-    }, 
+    },
     "operationSequence": {
-        "value": [
-            "fan_power%3D0", 
-            "set_temperature%3D24"
-        ]
-    }, 
+        "value": ["fan_power%3D0", "set_temperature%3D24"]
+    },
     "endDate": {
         "value": "2016-08-20T10:18:16Z"
-    }, 
+    },
     "description": {
         "value": "Air conditioning levels reduced due to out of hours"
-    }, 
+    },
     "refRelatedDeviceOperation": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": [
-            "36744245-6716-4a28-84c7-0e3d7520f143", 
+            "36744245-6716-4a28-84c7-0e3d7520f143",
             "33b2b713-9223-40a5-87a0-3f80a1264a6c"
         ]
-    }, 
+    },
     "dateCreated": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-08-08T10:18:16Z"
-    }, 
+    },
     "dateModified": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-08-08T10:18:16Z"
-    }, 
+    },
     "refRelatedBuildingOperation": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": [
-            "b4fb8bff-1a8f-455f-8cc0-ca43c069f865", 
+            "b4fb8bff-1a8f-455f-8cc0-ca43c069f865",
             "55c24793-3437-4157-9bda-667c9e1531fc"
         ]
-    }, 
+    },
     "source": {
         "value": "http://www.example.com"
-    }, 
+    },
     "refBuilding": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "building-a85e3da145c1"
-    }, 
+    },
     "result": {
         "value": "ok"
-    }, 
+    },
     "operationType": {
         "value": "airConditioning"
-    }, 
+    },
     "dateStarted": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-08-08T10:18:16Z"
-    }, 
+    },
     "dateFinished": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-08-20T10:18:16Z"
-    }, 
+    },
     "dataProvider": {
         "value": "OperatorA"
     }
@@ -188,33 +185,30 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
 {
-  "id": "57b912ab-eb47-4cd5-bc9d-73abece1f1b3",
-  "type": "BuildingOperation",
-  "dateCreated": "2016-08-08T10:18:16Z",
-  "dateModified": "2016-08-08T10:18:16Z",
-  "source":  "http://www.example.com",
-  "dataProvider": "OperatorA",
-  "refBuilding": "building-a85e3da145c1",
-  "operationType": "airConditioning",
-  "description": "Air conditioning levels reduced due to out of hours",
-  "result": "ok",
-  "startDate": "2016-08-08T10:18:16Z",
-  "endDate": "2016-08-20T10:18:16Z",
-  "dateStarted": "2016-08-08T10:18:16Z",
-  "dateFinished": "2016-08-20T10:18:16Z",
-  "status": "finished",
-  "operationSequence": [
-   "fan_power=0",
-   "set_temperature=24"
-  ],
-  "refRelatedBuildingOperation": [
-    "b4fb8bff-1a8f-455f-8cc0-ca43c069f865",
-    "55c24793-3437-4157-9bda-667c9e1531fc"
-  ],
-  "refRelatedDeviceOperation": [
-    "36744245-6716-4a28-84c7-0e3d7520f143",
-    "33b2b713-9223-40a5-87a0-3f80a1264a6c"
-  ]
+    "id": "57b912ab-eb47-4cd5-bc9d-73abece1f1b3",
+    "type": "BuildingOperation",
+    "dateCreated": "2016-08-08T10:18:16Z",
+    "dateModified": "2016-08-08T10:18:16Z",
+    "source": "http://www.example.com",
+    "dataProvider": "OperatorA",
+    "refBuilding": "building-a85e3da145c1",
+    "operationType": "airConditioning",
+    "description": "Air conditioning levels reduced due to out of hours",
+    "result": "ok",
+    "startDate": "2016-08-08T10:18:16Z",
+    "endDate": "2016-08-20T10:18:16Z",
+    "dateStarted": "2016-08-08T10:18:16Z",
+    "dateFinished": "2016-08-20T10:18:16Z",
+    "status": "finished",
+    "operationSequence": ["fan_power=0", "set_temperature=24"],
+    "refRelatedBuildingOperation": [
+        "b4fb8bff-1a8f-455f-8cc0-ca43c069f865",
+        "55c24793-3437-4157-9bda-667c9e1531fc"
+    ],
+    "refRelatedDeviceOperation": [
+        "36744245-6716-4a28-84c7-0e3d7520f143",
+        "33b2b713-9223-40a5-87a0-3f80a1264a6c"
+    ]
 }
 ```
 

--- a/specs/Device/Device/doc/spec.md
+++ b/specs/Device/Device/doc/spec.md
@@ -177,7 +177,7 @@ The data model is defined as shown below:
     determined.
 
     -   Type: [Number](https://schema.org/Number)
-    -   Allowed values: Interval [0,1]
+    -   Allowed values: Interval \[0,1\]
     -   Attribute metadata:
         -   `timestamp`: Timestamp when the last update of the attribute
             happened. This value can also appear as a FIWARE
@@ -243,59 +243,49 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 ### Normalized Example
 
 Normalized NGSI response
+
 ```json
 {
     "id": "device-9845A",
     "type": "Device",
     "category": {
-        "value": [
-            "sensor"
-        ]
-    }, 
+        "value": ["sensor"]
+    },
     "batteryLevel": {
         "value": 0.75
-    }, 
+    },
     "dateFirstUsed": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2014-09-11T11:00:00Z"
-    }, 
+    },
     "controlledAsset": {
-        "value": [
-            "wastecontainer-Osuna-100"
-        ]
-    }, 
+        "value": ["wastecontainer-Osuna-100"]
+    },
     "serialNumber": {
         "value": "9845A"
-    }, 
+    },
     "mcc": {
         "value": "214"
-    }, 
+    },
     "value": {
         "value": "l%3D0.22%3Bt%3D21.2"
-    }, 
+    },
     "refDeviceModel": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "myDevice-wastecontainer-sensor-345"
-    }, 
+    },
     "controlledProperty": {
-        "value": [
-            "fillingLevel", 
-            "temperature"
-        ]
-    }, 
+        "value": ["fillingLevel", "temperature"]
+    },
     "owner": {
-        "value": [
-            "http://person.org/leon"
-        ]
-    }, 
+        "value": ["http://person.org/leon"]
+    },
     "mnc": {
         "value": "07"
-    }, 
+    },
     "ipAddress": {
-        "value": [
-            "192.14.56.78"
-        ]
-    }, 
+        "value": ["192.14.56.78"]
+    },
     "deviceState": {
         "value": "ok"
     }

--- a/specs/Device/DeviceModel/doc/spec.md
+++ b/specs/Device/DeviceModel/doc/spec.md
@@ -172,32 +172,25 @@ Normalized NGSI response
     "id": "myDevice-wastecontainer-sensor-345",
     "type": "DeviceModel",
     "category": {
-        "value": [
-            "sensor"
-        ]
-    }, 
+        "value": ["sensor"]
+    },
     "function": {
-        "value": [
-            "sensing"
-        ]
-    }, 
+        "value": ["sensing"]
+    },
     "modelName": {
         "value": "S4Container 345"
-    }, 
+    },
     "name": {
         "value": "myDevice Sensor for Containers 345"
-    }, 
+    },
     "brandName": {
         "value": "myDevice"
-    }, 
+    },
     "manufacturerName": {
         "value": "myDevice Inc."
-    }, 
+    },
     "controlledProperty": {
-        "value": [
-            "fillingLevel", 
-            "temperature"
-        ]
+        "value": ["fillingLevel", "temperature"]
     }
 }
 ```
@@ -207,17 +200,17 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-        "id": "myDevice-wastecontainer-sensor-345",
-        "type": "DeviceModel",
-        "name": "myDevice Sensor for Containers 345",
-        "brandName": "myDevice",
-        "modelName": "S4Container 345",
-        "manufacturerName": "myDevice Inc.",
-        "category": ["sensor"],
-        "function": ["sensing"],
-        "controlledProperty": ["fillingLevel","temperature"]
-    }
+{
+    "id": "myDevice-wastecontainer-sensor-345",
+    "type": "DeviceModel",
+    "name": "myDevice Sensor for Containers 345",
+    "brandName": "myDevice",
+    "modelName": "S4Container 345",
+    "manufacturerName": "myDevice Inc.",
+    "category": ["sensor"],
+    "function": ["sensing"],
+    "controlledProperty": ["fillingLevel", "temperature"]
+}
 ```
 
 ## Test it with a real service

--- a/specs/Environment/AeroAllergenObserved/doc/spec.md
+++ b/specs/Environment/AeroAllergenObserved/doc/spec.md
@@ -194,52 +194,49 @@ Normalized NGSI response
     "id": "AeroAllergenObserved-CDMX-Pollen-Cuajimalpa",
     "type": "AeroAllergenObserved",
     "dateObserved": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2018-02-11T00:00:00.00Z"
-    }, 
+    },
     "alnus": {
         "value": 40
-    }, 
+    },
     "alnus_Allergenicity": {
         "value": "3"
-    }, 
+    },
     "allergenRisk": {
         "value": "moderate"
-    }, 
+    },
     "casuarina": {
         "value": 1
-    }, 
+    },
     "casuarina_Level": {
         "value": "low"
-    }, 
+    },
     "casuarina_Allergenicity": {
         "value": "3"
-    }, 
+    },
     "source": {
         "value": "http://rema.atmosfera.unam.mx/rema/"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -99.276977, 
-                19.381877
-            ]
+            "type": "Point",
+            "coordinates": [-99.276977, 19.381877]
         }
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressCountry": "MX", 
-            "addressLocality": "Ciudad de M\u00e9xico", 
+            "addressCountry": "MX",
+            "addressLocality": "Ciudad de M\u00e9xico",
             "streetAddress": "Colegio Franco-Ingl\u00e9s"
         }
-    }, 
+    },
     "dateModified": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2018-02-16T17:24:39.00Z"
-    }, 
+    },
     "alnus_Level": {
         "value": "moderate"
     }

--- a/specs/Environment/AirQualityObserved/README.md
+++ b/specs/Environment/AirQualityObserved/README.md
@@ -5,7 +5,7 @@ data as NGSI version 2.
 
 The data provided corresponds to different cities in Spain being the original
 data source different
-[air quality stations](../PointOfInterest/AirQualityStation) managed by
+[air quality stations](../../PointOfInterest/AirQualityStation/README.md) managed by
 municipalities or regional governments.
 
 Please check the original data source before making use of this data in an
@@ -18,7 +18,7 @@ The following scripts are present:
 -   `barcelona_air_quality_harvest.py`.- A data harvest and harmonization
     program for official Barcelona's Air Quality Data provided by Catalonia's
     Government.
--   `madrid_air_quality.py` .- Offers both an NGSIv2 endpoint and NGSI10 to
+-   `madrid_air_quality.py` .- Offers both an NGSI v2 endpoint and NGSI10 to
     provide ambient observed data (outdated)
 -   `ngsi_helper.py` .- Contains helper functions to support the NGSI protocol
     (outdated)

--- a/specs/Environment/AirQualityObserved/doc/spec.md
+++ b/specs/Environment/AirQualityObserved/doc/spec.md
@@ -88,7 +88,7 @@ A JSON Schema corresponding to this data model can be found
     corresponding to the air quality observed.
 
     -   Attribute type: [Number](https://schema.org/Number)
-    -   Allowed values: Interval [0,1]
+    -   Allowed values: Interval \[0,1\]
     -   Optional
 
 -   `refDevice` : A reference to the device(s) which captured this observation.

--- a/specs/Environment/NoiseLevelObserved/doc/spec.md
+++ b/specs/Environment/NoiseLevelObserved/doc/spec.md
@@ -51,12 +51,13 @@ The data model is defined as shown below:
 
 -   `name` : Name given to this observation.
 
-    -   Normative References: [https://schema.org/name]
+    -   Normative References: [https://schema.org/name](https://schema.org/name)
     -   Optional
 
 -   `description` : Description given to this observation.
 
-    -   Normative References: [https://schema.org/description]
+    -   Normative References:
+        [https://schema.org/description](https://schema.org/description)
     -   Optional
 
 -   `dateObserved` : The date and time of this observation represented by an

--- a/specs/Environment/WaterQualityObserved/doc/spec.md
+++ b/specs/Environment/WaterQualityObserved/doc/spec.md
@@ -264,32 +264,27 @@ Normalized NGSI response
     "id": "waterqualityobserved:Sevilla:D1",
     "type": "WaterQualityObserved",
     "dateObserved": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2017-01-31T06:45:00Z"
-    }, 
+    },
     "temperature": {
         "value": 24.4
-    }, 
+    },
     "NO3": {
         "value": 0.01
-    }, 
+    },
     "location": {
         "type": "geo:json",
         "value": {
             "type": "Point",
-            "coordinates": [
-                -5.993307,
-                37.362882
-            ]
+            "coordinates": [-5.993307, 37.362882]
         }
-    }, 
+    },
     "pH": {
         "value": 7.4
     },
     "measurand": {
-        "value": [
-            "NO3, 0.01, M1, Concentration of Nitrates"
-        ]
+        "value": ["NO3, 0.01, M1, Concentration of Nitrates"]
     },
     "conductivity": {
         "value": 0.005

--- a/specs/Environment/unsupported/AirQualityThreshold/README.md
+++ b/specs/Environment/unsupported/AirQualityThreshold/README.md
@@ -1,6 +1,6 @@
 # Air quality threshold
 
-This folder contains a NGSIv2 data set which provides the air quality thresholds
+This folder contains a NGSI v2 data set which provides the air quality thresholds
 in Europe.
 
 Air quality thresholds allow to calculate an air quality index (AQI).

--- a/specs/Environment/unsupported/README.md
+++ b/specs/Environment/unsupported/README.md
@@ -1,3 +1,3 @@
 # Unsupported folder
 
-These data models are not currently supported by the Community. 
+These data models are not currently supported by the Community.

--- a/specs/IssueTracking/Open311_ServiceRequest/doc/spec.md
+++ b/specs/IssueTracking/Open311_ServiceRequest/doc/spec.md
@@ -144,54 +144,49 @@ Normalized NGSI response
     "type": "Open311:ServiceRequest",
     "status": {
         "value": "closed"
-    }, 
+    },
     "description": {
         "value": "Acera en mal estado con bordillo partido en dos"
-    }, 
+    },
     "service_code": {
         "value": 234
-    }, 
+    },
     "status_notes": {
         "value": "Duplicate request."
-    }, 
+    },
     "service_name": {
         "value": "Aceras"
-    }, 
+    },
     "service_request_id": {
         "value": 638344
-    }, 
+    },
     "updated_datetime": {
         "value": "2010-04-14T06:37:38-08:00"
-    }, 
+    },
     "address_string": {
         "value": "Calle San Juan Bautista, 2"
-    }, 
+    },
     "requested_datetime": {
         "value": "2010-04-14T06:37:38-08:00"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -3.164485591715449, 
-                40.62785133667262
-            ]
+            "type": "Point",
+            "coordinates": [-3.164485591715449, 40.62785133667262]
         }
-    }, 
+    },
     "attributes": {
         "value": {
-            "ISSUE_TYPE": [
-                "Bordillo"
-            ]
+            "ISSUE_TYPE": ["Bordillo"]
         }
-    }, 
+    },
     "expected_datetime": {
         "value": "2010-04-15T06:37:38-08:00"
-    }, 
+    },
     "agency_responsible": {
         "value": "Ayuntamiento de Ciudad"
-    }, 
+    },
     "media_url": {
         "value": "http://exaple.org/media/638344.jpg"
     }
@@ -203,29 +198,29 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "service-request:638344",
-      "type": "Open311:ServiceRequest",
-      "service_request_id": 638344,
-      "status": "closed",
-      "status_notes": "Duplicate request.",
-      "service_name": "Aceras",
-      "service_code": 234,
-      "description": "Acera en mal estado con bordillo partido en dos",
-      "agency_responsible": "Ayuntamiento de Ciudad",
-      "requested_datetime": "2010-04-14T06:37:38-08:00",
-      "updated_datetime": "2010-04-14T06:37:38-08:00",
-      "expected_datetime": "2010-04-15T06:37:38-08:00",
-      "address_string": "Calle San Juan Bautista, 2",
-      "attributes": {
-         "ISSUE_TYPE": ["Bordillo"]
-      },
-      "location": {
+{
+    "id": "service-request:638344",
+    "type": "Open311:ServiceRequest",
+    "service_request_id": 638344,
+    "status": "closed",
+    "status_notes": "Duplicate request.",
+    "service_name": "Aceras",
+    "service_code": 234,
+    "description": "Acera en mal estado con bordillo partido en dos",
+    "agency_responsible": "Ayuntamiento de Ciudad",
+    "requested_datetime": "2010-04-14T06:37:38-08:00",
+    "updated_datetime": "2010-04-14T06:37:38-08:00",
+    "expected_datetime": "2010-04-15T06:37:38-08:00",
+    "address_string": "Calle San Juan Bautista, 2",
+    "attributes": {
+        "ISSUE_TYPE": ["Bordillo"]
+    },
+    "location": {
         "type": "Point",
-        "coordinates": [  -3.164485591715449, 40.62785133667262 ]
-      },
-      "media_url":"http://exaple.org/media/638344.jpg"
-    }
+        "coordinates": [-3.164485591715449, 40.62785133667262]
+    },
+    "media_url": "http://exaple.org/media/638344.jpg"
+}
 ```
 
 ## Test it with real services

--- a/specs/IssueTracking/Open311_ServiceType/doc/spec.md
+++ b/specs/IssueTracking/Open311_ServiceType/doc/spec.md
@@ -100,48 +100,48 @@ Normalized NGSI response
     "type": "Open311:ServiceType",
     "group": {
         "value": "street"
-    }, 
+    },
     "description": {
         "value": "When a sidewalk is broken or dirty allows citizens to request a fix"
-    }, 
+    },
     "service_code": {
         "value": 234
-    }, 
+    },
     "service_name": {
         "value": "Aceras"
-    }, 
+    },
     "open311:type": {
         "value": "realtime"
-    }, 
+    },
     "jurisdiction_id": {
         "value": "www.smartguadalajara.com"
-    }, 
+    },
     "dateCreated": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2007-01-01T12:00:00Z"
-    }, 
+    },
     "keywords": {
         "value": "street,sidewalk, cleaning, repair"
-    }, 
+    },
     "attributes": {
         "value": [
             {
-                "code": "ISSUE_TYPE", 
-                "description": "What is the identified problem at the sidewalk?", 
-                "datatype": "singlevaluelist", 
-                "required": true, 
+                "code": "ISSUE_TYPE",
+                "description": "What is the identified problem at the sidewalk?",
+                "datatype": "singlevaluelist",
+                "required": true,
                 "values": [
                     {
-                        "name": "Bump", 
+                        "name": "Bump",
                         "key": 123
-                    }, 
+                    },
                     {
-                        "name": "Dirty", 
+                        "name": "Dirty",
                         "key": 124
                     }
-                ], 
-                "variable": true, 
-                "order": 1, 
+                ],
+                "variable": true,
+                "order": 1,
                 "datatype_description": null
             }
         ]
@@ -154,39 +154,39 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "o311:servicetype-guadalajara-sidewalks",
-      "type": "Open311:ServiceType",
-      "dateCreated": "2007-01-01T12:00:00Z",
-      "jurisdiction_id": "www.smartguadalajara.com",
-      "open311:type": "realtime",
-      "service_code": 234,
-      "service_name": "Aceras",
-      "description": "When a sidewalk is broken or dirty allows citizens to request a fix",
-      "keywords": "street,sidewalk, cleaning, repair",
-      "group": "street",
-      "attributes": [
+{
+    "id": "o311:servicetype-guadalajara-sidewalks",
+    "type": "Open311:ServiceType",
+    "dateCreated": "2007-01-01T12:00:00Z",
+    "jurisdiction_id": "www.smartguadalajara.com",
+    "open311:type": "realtime",
+    "service_code": 234,
+    "service_name": "Aceras",
+    "description": "When a sidewalk is broken or dirty allows citizens to request a fix",
+    "keywords": "street,sidewalk, cleaning, repair",
+    "group": "street",
+    "attributes": [
         {
-          "variable": true,
-          "code": "ISSUE_TYPE",
-          "datatype": "singlevaluelist",
-          "required": true,
-          "datatype_description": null,
-          "order": 1,
-          "description": "What is the identified problem at the sidewalk?",
-          "values": [
-            {
-              "key": 123,
-              "name": "Bump"
-            },
-            {
-              "key": 124,
-              "name":"Dirty"
-            }
-          ]
+            "variable": true,
+            "code": "ISSUE_TYPE",
+            "datatype": "singlevaluelist",
+            "required": true,
+            "datatype_description": null,
+            "order": 1,
+            "description": "What is the identified problem at the sidewalk?",
+            "values": [
+                {
+                    "key": 123,
+                    "name": "Bump"
+                },
+                {
+                    "key": 124,
+                    "name": "Dirty"
+                }
+            ]
         }
-      ]
-    }
+    ]
+}
 ```
 
 ## Test it with a real service

--- a/specs/KeyPerformanceIndicator/doc/spec.md
+++ b/specs/KeyPerformanceIndicator/doc/spec.md
@@ -222,56 +222,54 @@ Normalized NGSI response
     "id": "kpi-2016-Ciudad-containers-faults",
     "type": "KeyPerformanceIndicator",
     "category": {
-        "value": [
-            "quantitative"
-        ]
-    }, 
+        "value": ["quantitative"]
+    },
     "dateModified": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-06-29T15:59:09.224Z"
-    }, 
+    },
     "calculationFrequency": {
         "value": "monthly"
-    }, 
+    },
     "description": {
         "value": "Number of incidences raised on containers per month"
-    }, 
+    },
     "currentStanding": {
         "value": "good"
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "Ciudad", 
+            "addressLocality": "Ciudad",
             "addressCountry": "ESP"
         }
-    }, 
+    },
     "calculationPeriod": {
         "value": {
-            "to": "2016-06-30", 
+            "to": "2016-06-30",
             "from": "2016-06-01"
         }
-    }, 
+    },
     "dateNextCalculation": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-07-31"
-    }, 
+    },
     "calculationMethod": {
         "value": "automatic"
-    }, 
+    },
     "provider": {
         "value": {
             "name": "Cleaning Service Provider S.A."
         }
-    }, 
+    },
     "organization": {
         "value": {
             "name": "Ayuntamiento de Ciudad"
         }
-    }, 
+    },
     "kpiValue": {
         "value": 20
-    }, 
+    },
     "name": {
         "value": "Incidencias-Contenedores-Mensual"
     }
@@ -283,33 +281,33 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "kpi-2016-Ciudad-containers-faults",
-      "type": "KeyPerformanceIndicator",
-      "name": "Incidencias-Contenedores-Mensual",
-      "description": "Number of incidences raised on containers per month",
-      "category": ["quantitative"],
-      "organization": {
-         "name": "Ayuntamiento de Ciudad"
-      },
-      "provider": {
-         "name": "Cleaning Service Provider S.A."
-      },
-      "kpiValue": 20,
-      "currentStanding": "good",
-      "calculationPeriod": {
+{
+    "id": "kpi-2016-Ciudad-containers-faults",
+    "type": "KeyPerformanceIndicator",
+    "name": "Incidencias-Contenedores-Mensual",
+    "description": "Number of incidences raised on containers per month",
+    "category": ["quantitative"],
+    "organization": {
+        "name": "Ayuntamiento de Ciudad"
+    },
+    "provider": {
+        "name": "Cleaning Service Provider S.A."
+    },
+    "kpiValue": 20,
+    "currentStanding": "good",
+    "calculationPeriod": {
         "from": "2016-06-01",
-        "to":   "2016-06-30"
-      },
-      "calculationMethod": "automatic",
-      "calculationFrequency": "monthly",
-      "dateModified": "2016-06-29T15:59:09.224Z",
-      "dateNextCalculation": "2016-07-31",
-      "address": {
+        "to": "2016-06-30"
+    },
+    "calculationMethod": "automatic",
+    "calculationFrequency": "monthly",
+    "dateModified": "2016-06-29T15:59:09.224Z",
+    "dateNextCalculation": "2016-07-31",
+    "address": {
         "addressLocality": "Ciudad",
         "addressCountry": "ESP"
-      }
     }
+}
 ```
 
 ## Test it with a real service

--- a/specs/Parking/OffStreetParking/doc/spec.md
+++ b/specs/Parking/OffStreetParking/doc/spec.md
@@ -151,7 +151,8 @@ The data model is defined as shown below:
 
 -   `acceptedPaymentMethod` : Accepted payment method(s).
 
-    -   Normative references: https://schema.org/acceptedPaymentMethod
+    -   Normative references:
+        [https://schema.org/acceptedPaymentMethod](https://schema.org/acceptedPaymentMethod)
     -   Optional
 
 -   `priceRatePerMinute` : Price rate per minute.

--- a/specs/Parking/OnStreetParking/README.md
+++ b/specs/Parking/OnStreetParking/README.md
@@ -1,7 +1,7 @@
 # Street parking
 
 This folder holds all the code needed to support datasets which expose
-`StreetParking` instances as NGSIv2.
+`StreetParking` instances as NGSI v2.
 
 The list below provides a description of the files present in this folder:
 

--- a/specs/Parking/OnStreetParking/README.md
+++ b/specs/Parking/OnStreetParking/README.md
@@ -27,7 +27,7 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```bash
 curl http://130.206.83.68:1026/v2/entities?type=StreetParking
 ```
 

--- a/specs/Parking/OnStreetParking/doc/spec.md
+++ b/specs/Parking/OnStreetParking/doc/spec.md
@@ -100,10 +100,10 @@ The data model is defined as shown below:
     value which must contain a subproperty per each required permit, indicating
     when the permit is active. If nothing specified (or `null`) for a permit it
     will mean that a permit is always required. `null`or empty object means
-    always active. The syntax must be conformant with schema.org (opening hours
-    specification)[https://schema.org/openingHours]. For instance, a blue zone
-    which is only active on dayweeks will be encoded as "blueZonePermit":
-    "Mo,Tu,We,Th,Fr,Sa 09:00-20:00".
+    always active. The syntax must be conformant with schema.org
+    [opening hours specification](https://schema.org/openingHours). For
+    instance, a blue zone which is only active on dayweeks will be encoded as
+    "blueZonePermit": "Mo,Tu,We,Th,Fr,Sa 09:00-20:00".
 
     -   Attribute type: [StructuredValue](http://schema.org/StructuredValue)
     -   Mandatory. It can be `null`.
@@ -219,7 +219,8 @@ The data model is defined as shown below:
 
 -   `acceptedPaymentMethod` : Accepted payment method(s)
 
-    -   Normative references: https://schema.org/acceptedPaymentMethod
+    -   Normative references:
+        [https://schema.org/acceptedPaymentMethod](https://schema.org/acceptedPaymentMethod)
     -   Optional
 
 -   `image` : A URL containing a photo of this parking site.

--- a/specs/Parking/ParkingSpot/doc/spec.md
+++ b/specs/Parking/ParkingSpot/doc/spec.md
@@ -89,7 +89,7 @@ The data model is defined as shown below:
         saved by FIWARE's IoT Agents. Note: This attribute has not been
         harmonized to keep backwards compatibility with current FIWARE reference
         implementations.
-        -   Type: [DateTime]((https://schema.org/DateTime). here can be
+        -   Type: [DateTime](https://schema.org/DateTime). here can be
             production environmments where the attribute type is equal to the
             `ISO8601` string. If so, it must be considered as a synonym of
             `DateTime`.

--- a/specs/ParksAndGardens/FlowerBed/doc/spec.md
+++ b/specs/ParksAndGardens/FlowerBed/doc/spec.md
@@ -120,25 +120,23 @@ Normalized NGSI response
     "id": "FlowerBed-345",
     "type": "FlowerBed",
     "category": {
-        "value": [
-            "urbanTreeSpot"
-        ]
-    }, 
+        "value": ["urbanTreeSpot"]
+    },
     "soilMoistureVwc": {
         "value": 0.85
-    }, 
+    },
     "dateLastWatering": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2017-03-31T08:00"
-    }, 
+    },
     "soilTemperature": {
         "value": 17
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressCountry": "Spain", 
-            "streetAddress": "Paseo Zorrilla, 122", 
+            "addressCountry": "Spain",
+            "streetAddress": "Paseo Zorrilla, 122",
             "adressLocality": "Valladolid"
         }
     }

--- a/specs/ParksAndGardens/Garden/doc/spec.md
+++ b/specs/ParksAndGardens/Garden/doc/spec.md
@@ -56,7 +56,8 @@ A JSON Schema corresponding to this data model can be found
     -   Optional
 -   `description` : Garden's description
 
-    -   Normative References: [https://schema.org/description]
+    -   Normative References:
+        [https://schema.org/description](https://schema.org/description)
     -   Optional
 
 -   `category` : Garden's category.
@@ -73,7 +74,8 @@ A JSON Schema corresponding to this data model can be found
     -   Optional
 
 -   `openingHours` : Opening hours of this garden.
-    -   Normative references: [https://schema.org/openingHours]
+    -   Normative references:
+        [https://schema.org/openingHours](https://schema.org/openingHours)
     -   Optional
 -   `areaServed` : Higher level area to which the garden belongs to. It can be
     used to group gardens per responsible, district, neighbourhood, etc.
@@ -110,50 +112,43 @@ Normalized NGSI response
     "id": "Santander-Garden-Piquio",
     "type": "Garden",
     "category": {
-        "value": [
-            "public"
-        ]
-    }, 
+        "value": ["public"]
+    },
     "style": {
         "value": "french"
-    }, 
+    },
     "description": {
         "value": "Jardines de Piquio. Zona El Sardinero"
-    }, 
+    },
     "dateLastWatering": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2017-03-31T:08:00"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -3.7836974, 
-                43.4741091
-            ]
+            "type": "Point",
+            "coordinates": [-3.7836974, 43.4741091]
         }
-    }, 
+    },
     "refRecord": {
-        "type": "Relationship", 
-        "value": [
-            "Santander-Garden-Piquio-Record-1"
-        ]
-    }, 
+        "type": "Relationship",
+        "value": ["Santander-Garden-Piquio-Record-1"]
+    },
     "areaServed": {
         "value": "El Sardinero"
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "Santander", 
-            "postalCode": "39005", 
+            "addressLocality": "Santander",
+            "postalCode": "39005",
             "streetAddress": "Avenida Casta\u00f1eda"
         }
-    }, 
+    },
     "openingHours": {
         "value": "Mo-Su"
-    }, 
+    },
     "name": {
         "value": "Jardines de Piquio"
     }

--- a/specs/ParksAndGardens/GreenspaceRecord/doc/spec.md
+++ b/specs/ParksAndGardens/GreenspaceRecord/doc/spec.md
@@ -120,25 +120,22 @@ Normalized NGSI response
     "id": "Santander-Garden-Piquio-Record-1",
     "type": "GreenspaceRecord",
     "refGreenspace": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "Santander-Garden-Piquio"
-    }, 
+    },
     "temperature": {
         "value": 17
-    }, 
+    },
     "soilTemperature": {
         "value": 13
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -3.7836974, 
-                43.4741091
-            ]
+            "type": "Point",
+            "coordinates": [-3.7836974, 43.4741091]
         }
-    }, 
+    },
     "relativeHumidity": {
         "value": 0.87
     },

--- a/specs/PointOfInteraction/SmartPointOfInteraction/doc/spec.md
+++ b/specs/PointOfInteraction/SmartPointOfInteraction/doc/spec.md
@@ -99,55 +99,39 @@ Normalized NGSI response
     "id": "SPOI-ES-4326",
     "type": "SmartPointOfInteraction",
     "category": {
-        "value": [
-            "co-creation"
-        ]
-    }, 
+        "value": ["co-creation"]
+    },
     "applicationUrl": {
         "type": "URL",
         "value": "http://www.example.org"
-    }, 
+    },
     "areaCovered": {
         "value": {
-            "type": "Polygon", 
+            "type": "Polygon",
             "coordinates": [
                 [
-                    [
-                        25.774, 
-                        -80.19
-                    ], 
-                    [
-                        18.466, 
-                        -66.118
-                    ], 
-                    [
-                        32.321, 
-                        -64.757
-                    ], 
-                    [
-                        25.774, 
-                        -80.19
-                    ]
+                    [25.774, -80.19],
+                    [18.466, -66.118],
+                    [32.321, -64.757],
+                    [25.774, -80.19]
                 ]
             ]
         }
-    }, 
+    },
     "availability": {
         "value": "Tu,Th 16:00-20:00"
-    }, 
+    },
     "refSmartSpot": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": [
-            "SSPOT-F94C58E29DD5", 
-            "SSPOT-F94C53E21DD2", 
+            "SSPOT-F94C58E29DD5",
+            "SSPOT-F94C53E21DD2",
             "SSPOT-F94C51A295D9"
         ]
-    }, 
+    },
     "refRelatedEntity": {
-        "type": "Relationship", 
-        "value": [
-            "POI-PlazaCazorla-3123"
-        ]
+        "type": "Relationship",
+        "value": ["POI-PlazaCazorla-3123"]
     }
 }
 ```

--- a/specs/PointOfInteraction/SmartSpot/doc/spec.md
+++ b/specs/PointOfInteraction/SmartSpot/doc/spec.md
@@ -98,24 +98,24 @@ Normalized NGSI response
     "type": "SmartSpot",
     "announcementPeriod": {
         "value": 500
-    }, 
+    },
     "signalStrength": {
         "value": "highest"
-    }, 
+    },
     "announcedUrl": {
         "value": "http://goo.gl/EJ81JP"
-    }, 
+    },
     "availability": {
         "value": "Tu,Th 16:00-20:00"
-    }, 
+    },
     "coverageRadius": {
         "value": 30
-    }, 
+    },
     "bluetoothChannel": {
         "value": "37,38,39"
-    }, 
+    },
     "refSmartPointOfInteraction": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "SPOI-ES-4326"
     }
 }

--- a/specs/PointOfInterest/AirQualityStation/README.md
+++ b/specs/PointOfInterest/AirQualityStation/README.md
@@ -18,7 +18,7 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```bash
 curl http://130.206.83.68:1027/v2/entities?type=PointOfInterest&q=category:AirQualityStation
 ```
 
@@ -44,6 +44,6 @@ curl http://130.206.83.68:1027/v2/entities?type=PointOfInterest&q=category:AirQu
 If you want to know the Air Quality Stations close to a certain location, for
 instance Plaza de España
 
-```
+```text
 http://130.206.83.68:1027/v2/entities?type=PointOfInterest&q=category:AirQualityStation&limit=100&georel=near;maxDistance=2000&coords=40.42,-3.71
 ```

--- a/specs/PointOfInterest/Beach/doc/spec.md
+++ b/specs/PointOfInterest/Beach/doc/spec.md
@@ -128,58 +128,42 @@ Normalized NGSI response
     "type": "Beach",
     "description": {
         "value": "La Playa de A Concha se presenta ....."
-    }, 
+    },
     "width": {
         "value": 51
-    }, 
+    },
     "accessType": {
-        "value": [
-            "privateVehicle", 
-            "onFoot", 
-            "publicTransport"
-        ]
-    }, 
+        "value": ["privateVehicle", "onFoot", "publicTransport"]
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -8.768460000000001, 
-                42.60214472222222
-            ]
+            "type": "Point",
+            "coordinates": [-8.768460000000001, 42.60214472222222]
         }
-    }, 
+    },
     "facilities": {
-        "value": [
-            "promenade", 
-            "showers", 
-            "cleaningServices", 
-            "lifeGuard"
-        ]
-    }, 
+        "value": ["promenade", "showers", "cleaningServices", "lifeGuard"]
+    },
     "length": {
         "value": 450
-    }, 
+    },
     "source": {
         "value": "http://www.tourspain.es"
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressCountry": "ES", 
+            "addressCountry": "ES",
             "addressLocality": "Vilagarc\u00eda de Arousa"
         }
-    }, 
+    },
     "beachType": {
-        "value": [
-            "whiteSand", 
-            "urban", 
-            "calmWaters"
-        ]
-    }, 
+        "value": ["whiteSand", "urban", "calmWaters"]
+    },
     "occupationRate": {
         "value": "high"
-    }, 
+    },
     "name": {
         "value": "Playa de a Concha"
     }

--- a/specs/PointOfInterest/Museum/doc/spec.md
+++ b/specs/PointOfInterest/Museum/doc/spec.md
@@ -55,7 +55,7 @@ used by applications.
 -   `description` : Description of this museum.
 
     -   Normative References:
-        [https://schema.org/description](https://schema.org/description]
+        [https://schema.org/description](https://schema.org/description)
     -   Optional
 
 -   `location` : Location of this museum represented by a GeoJSON geometry,
@@ -178,70 +178,59 @@ Normalized NGSI response
     "type": "Museum",
     "alternateName": {
         "value": "MACBA"
-    }, 
+    },
     "openingHoursSpecification": {
         "value": [
             {
-                "dayOfWeek": "Mo, Wed, Thu, Fr", 
-                "closes": "19:30", 
+                "dayOfWeek": "Mo, Wed, Thu, Fr",
+                "closes": "19:30",
                 "opens": "11:00"
-            }, 
+            },
             {
-                "dayOfWeek": "Sat", 
-                "closes": "21:00", 
+                "dayOfWeek": "Sat",
+                "closes": "21:00",
                 "opens": "10:00"
-            }, 
+            },
             {
-                "dayOfWeek": "Sun", 
-                "closes": "15:00", 
+                "dayOfWeek": "Sun",
+                "closes": "15:00",
                 "opens": "10:00"
             }
         ]
-    }, 
+    },
     "description": {
         "value": "The MACBA was designed by the American architect Richard Meier and inaugurated in 1995."
-    }, 
+    },
     "source": {
         "value": "http://www.tourspain.es"
-    }, 
+    },
     "artPeriod": {
-        "value": [
-            "contemporary"
-        ]
-    }, 
+        "value": ["contemporary"]
+    },
     "museumType": {
-        "value": [
-            "fineArts"
-        ]
-    }, 
+        "value": ["fineArts"]
+    },
     "facilities": {
-        "value": [
-            "shop", 
-            "cloakRoom", 
-            "guidedTour"
-        ]
-    }, 
+        "value": ["shop", "cloakRoom", "guidedTour"]
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                2.1668771521199393, 
-                41.38302235796602
-            ]
+            "type": "Point",
+            "coordinates": [2.1668771521199393, 41.38302235796602]
         }
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressCountry": "ES", 
-            "addressLocality": "Barcelona", 
+            "addressCountry": "ES",
+            "addressLocality": "Barcelona",
             "streetAddress": "Plaza Dels \u00c0ngels, 1"
         }
-    }, 
+    },
     "touristArea": {
         "value": "Barcelona-Capital"
-    }, 
+    },
     "name": {
         "value": "Museo de Arte Contemporaneo de Barcelona"
     }
@@ -253,44 +242,44 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-         "id": "Museum-Barcelona-MACBA-1234",
-         "type": "Museum",
-         "name": "Museo de Arte Contemporaneo de Barcelona",
-         "alternateName": "MACBA",
-         "description": "The MACBA was designed by the American architect Richard Meier and inaugurated in 1995.",
-         "address": {
-            "addressCountry": "ES",
-            "addressLocality": "Barcelona",
-            "streetAddress": "Plaza Dels Àngels, 1"
-         },
-         "museumType": ["fineArts"],
-         "artPeriod": ["contemporary"],
-         "facilities": ["shop", "cloakRoom", "guidedTour"],
-         "location": {
-            "type": "Point",
-            "coordinates": [ 2.1668771521199393, 41.38302235796602]
-         },
-         "openingHoursSpecification": [
-            {
-                "opens":  "11:00",
-                "closes": "19:30",
-                "dayOfWeek": "Mo, Wed, Thu, Fr"
-            },
-            {
-                "opens": "10:00",
-                "closes": "21:00",
-                "dayOfWeek": "Sat"
-            },
-            {
-                "opens": "10:00",
-                "closes": "15:00",
-                "dayOfWeek": "Sun"
-            }
-        ],
-        "touristArea": "Barcelona-Capital",
-        "source": "http://www.tourspain.es"
-    }
+{
+    "id": "Museum-Barcelona-MACBA-1234",
+    "type": "Museum",
+    "name": "Museo de Arte Contemporaneo de Barcelona",
+    "alternateName": "MACBA",
+    "description": "The MACBA was designed by the American architect Richard Meier and inaugurated in 1995.",
+    "address": {
+        "addressCountry": "ES",
+        "addressLocality": "Barcelona",
+        "streetAddress": "Plaza Dels Àngels, 1"
+    },
+    "museumType": ["fineArts"],
+    "artPeriod": ["contemporary"],
+    "facilities": ["shop", "cloakRoom", "guidedTour"],
+    "location": {
+        "type": "Point",
+        "coordinates": [2.1668771521199393, 41.38302235796602]
+    },
+    "openingHoursSpecification": [
+        {
+            "opens": "11:00",
+            "closes": "19:30",
+            "dayOfWeek": "Mo, Wed, Thu, Fr"
+        },
+        {
+            "opens": "10:00",
+            "closes": "21:00",
+            "dayOfWeek": "Sat"
+        },
+        {
+            "opens": "10:00",
+            "closes": "15:00",
+            "dayOfWeek": "Sun"
+        }
+    ],
+    "touristArea": "Barcelona-Capital",
+    "source": "http://www.tourspain.es"
+}
 ```
 
 ## Use it with a real service

--- a/specs/PointOfInterest/PointOfInterest/doc/spec.md
+++ b/specs/PointOfInterest/PointOfInterest/doc/spec.md
@@ -149,26 +149,23 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-        "id": "PointOfInterest-A-Concha-123456",
-        "type": "PointOfInterest",
-        "name": "Playa de a Concha",
-        "description": "La Playa de A Concha se presenta como una continuación de la Playa de Compostela, una de las más frecuentadas de Vilagarcía.",
-        "address": {
-          "addressCountry": "ES",
-          "addressLocality": "Vilagarcía de Arousa"
-        },
-        "category": ["113"],
-        "location": {
-          "type": "Point",
-          "coordinates": [
-            -8.768460000000001,
-            42.60214472222222
-          ]
-        },
-        "source": "http://www.tourspain.es",
-        "refSeeAlso": ["Beach-A-Concha-123456"]
-    }
+{
+    "id": "PointOfInterest-A-Concha-123456",
+    "type": "PointOfInterest",
+    "name": "Playa de a Concha",
+    "description": "La Playa de A Concha se presenta como una continuación de la Playa de Compostela, una de las más frecuentadas de Vilagarcía.",
+    "address": {
+        "addressCountry": "ES",
+        "addressLocality": "Vilagarcía de Arousa"
+    },
+    "category": ["113"],
+    "location": {
+        "type": "Point",
+        "coordinates": [-8.768460000000001, 42.60214472222222]
+    },
+    "source": "http://www.tourspain.es",
+    "refSeeAlso": ["Beach-A-Concha-123456"]
+}
 ```
 
 ## Use it with a real service

--- a/specs/PointOfInterest/README.md
+++ b/specs/PointOfInterest/README.md
@@ -1,6 +1,6 @@
 # Point Of interest
 
-This folder contains all the code related to a harmonized NGSIv2 endpoint.
+This folder contains all the code related to a harmonized NGSI v2 endpoint.
 
 Such endpoint serves entities of type `PointOfInterest`. Data comes from
 different sources:

--- a/specs/PointOfInterest/README.md
+++ b/specs/PointOfInterest/README.md
@@ -18,7 +18,7 @@ commercial application.
 
 Currently the following categories are supported: (For a more extended list of
 categories please check
-https://github.com/Factual/places/blob/master/categories/factual_taxonomy.json)
+[factual_taxonomy.json](https://github.com/Factual/places/blob/master/categories/factual_taxonomy.json))
 
 -   `OffStreetParking: 418`
 -   `Restaurant: 347`

--- a/specs/PointOfInterest/WeatherStation/README.md
+++ b/specs/PointOfInterest/WeatherStation/README.md
@@ -15,7 +15,7 @@ Here you can find the following files:
 -   `aemet-st.js`. This script loads all the weather stations to Orion Context
     Broker.
 
-```
+```bash
 curl http://130.206.83.68:1027/v2/entities?type=PointOfInterest&q=category:WeatherStation
 ```
 
@@ -41,6 +41,6 @@ curl http://130.206.83.68:1027/v2/entities?type=PointOfInterest&q=category:Weath
 If you want to know the Weather Stations close to a certain location, for
 instance Santander (Spain), you can issue a GET request like
 
-```
+```text
 http://130.206.83.68:1027/v2/entities?type=PointOfInterest&q=category:WeatherStation&georel=near;maxDistance=10000&coords=43.4275,-3.8224
 ```

--- a/specs/StreetLighting/Streetlight/doc/spec.md
+++ b/specs/StreetLighting/Streetlight/doc/spec.md
@@ -53,7 +53,7 @@ The data model is defined as shown below:
     from. Typically it will contain an identifier that will allow to obtain more
     information about such circuit.
 
-    -   Attribute type: Text](http://schema.org/Text)
+    -   Attribute type: [Text](http://schema.org/Text)
     -   Optional
 
 -   `refStreetlightModel` : Streetlight's model.
@@ -211,45 +211,42 @@ Normalized NGSI response
     "type": "Streetlight",
     "status": {
         "value": "ok"
-    }, 
+    },
     "powerState": {
         "value": "off"
-    }, 
+    },
     "circuit": {
         "value": "C-456-A467"
-    }, 
+    },
     "locationCategory": {
         "value": "centralIsland"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -3.164485591715449, 
-                40.62785133667262
-            ]
+            "type": "Point",
+            "coordinates": [-3.164485591715449, 40.62785133667262]
         }
-    }, 
+    },
     "areaServed": {
         "value": "Roundabouts city entrance"
-    }, 
+    },
     "controllingMethod": {
         "value": "individual"
-    }, 
+    },
     "refStreetlightGroup": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "streetlightgroup:G345"
-    }, 
+    },
     "dateLastLampChange": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-07-08T08:02:21.753Z"
-    }, 
+    },
     "lanternHeight": {
         "value": 10
-    }, 
+    },
     "refStreetlightModel": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "streetlightmodel:STEEL_Tubular_10m"
     }
 }
@@ -260,24 +257,24 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "streetlight:guadalajara:4567",
-      "type": "Streetlight",
-      "location": {
+{
+    "id": "streetlight:guadalajara:4567",
+    "type": "Streetlight",
+    "location": {
         "type": "Point",
-        "coordinates": [  -3.164485591715449, 40.62785133667262 ]
-      },
-      "areaServed": "Roundabouts city entrance",
-      "status": "ok",
-      "refStreetlightGroup": "streetlightgroup:G345",
-      "refStreetlightModel": "streetlightmodel:STEEL_Tubular_10m",
-      "circuit": "C-456-A467",
-      "lanternHeight": 10,
-      "locationCategory" : "centralIsland",
-      "powerState": "off",
-      "controllingMethod": "individual",
-      "dateLastLampChange": "2016-07-08T08:02:21.753Z"
-    }
+        "coordinates": [-3.164485591715449, 40.62785133667262]
+    },
+    "areaServed": "Roundabouts city entrance",
+    "status": "ok",
+    "refStreetlightGroup": "streetlightgroup:G345",
+    "refStreetlightModel": "streetlightmodel:STEEL_Tubular_10m",
+    "circuit": "C-456-A467",
+    "lanternHeight": 10,
+    "locationCategory": "centralIsland",
+    "powerState": "off",
+    "controllingMethod": "individual",
+    "dateLastLampChange": "2016-07-08T08:02:21.753Z"
+}
 ```
 
 ## Test it with a real service

--- a/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -186,7 +186,7 @@ The data model is defined as shown below:
     -   Attribute metadata:
         -   `timestamp`: Timestamp when the last update of the attribute
             happened.
-            -   Type: [DateTime](http://schema.org/DateTime
+            -   Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
 -   `dateMeteringStarted` : The starting date for metering energy consumed.
@@ -345,69 +345,61 @@ Normalized NGSI response
     "type": "StreetlightControlCabinet",
     "modelName": {
         "value": "Simatic S7 1200"
-    }, 
+    },
     "lastMeterReading": {
         "value": 161237
-    }, 
+    },
     "dateMeteringStarted": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2013-07-07T15:05:59.408Z"
-    }, 
+    },
     "dateLastProgramming": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-07-08T16:04:30.201Z"
-    }, 
+    },
     "refStreetlightGroup": {
-        "type": "Relationship", 
-        "value": [
-            "streetlightgroup:BG678", 
-            "streetlightgroup:789"
-        ]
-    }, 
+        "type": "Relationship",
+        "value": ["streetlightgroup:BG678", "streetlightgroup:789"]
+    },
     "compliantWith": {
-        "value": [
-            "IP54"
-        ]
-    }, 
+        "value": ["IP54"]
+    },
     "intensity": {
         "value": {
-            "S": 14.4, 
-            "R": 20.1, 
+            "S": 14.4,
+            "R": 20.1,
             "T": 22
         }
-    }, 
+    },
     "workingMode": {
         "value": "automatic"
-    }, 
+    },
     "energyConsumed": {
         "value": 162456
-    }, 
+    },
     "meterReadingPeriod": {
         "value": 60
-    }, 
+    },
     "cupboardMadeOf": {
         "value": "plastic"
-    }, 
+    },
     "brandName": {
         "value": "Siemens"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -3.164485591715449, 
-                40.62785133667262
-            ]
+            "type": "Point",
+            "coordinates": [-3.164485591715449, 40.62785133667262]
         }
-    }, 
+    },
     "reactivePower": {
         "value": {
-            "S": 43.5, 
-            "R": 45, 
+            "S": 43.5,
+            "R": 45,
             "T": 42
         }
-    }, 
+    },
     "maximumPowerAvailable": {
         "value": 10
     }
@@ -419,36 +411,36 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "streetlightcontrolcabinet:A45HGJK",
-      "type": "StreetlightControlCabinet",
-      "location": {
+{
+    "id": "streetlightcontrolcabinet:A45HGJK",
+    "type": "StreetlightControlCabinet",
+    "location": {
         "type": "Point",
-        "coordinates": [  -3.164485591715449, 40.62785133667262 ]
-      },
-      "cupboardMadeOf": "plastic",
-      "brandName": "Siemens",
-      "modelName": "Simatic S7 1200",
-      "refStreetlightGroup": ["streetlightgroup:BG678", "streetlightgroup:789"],
-      "compliantWith": ["IP54"],
-      "dateLastProgramming": "2016-07-08T16:04:30.201Z",
-      "maximumPowerAvailable": 10,
-      "energyConsumed": 162456,
-      "dateMeteringStarted": "2013-07-07T15:05:59.408Z",
-      "lastMeterReading": 161237,
-      "meterReadingPeriod": 60,
-      "intensity": {
-         "R": 20.1,
-         "S": 14.4,
-         "T": 22
-      },
-      "reactivePower": {
+        "coordinates": [-3.164485591715449, 40.62785133667262]
+    },
+    "cupboardMadeOf": "plastic",
+    "brandName": "Siemens",
+    "modelName": "Simatic S7 1200",
+    "refStreetlightGroup": ["streetlightgroup:BG678", "streetlightgroup:789"],
+    "compliantWith": ["IP54"],
+    "dateLastProgramming": "2016-07-08T16:04:30.201Z",
+    "maximumPowerAvailable": 10,
+    "energyConsumed": 162456,
+    "dateMeteringStarted": "2013-07-07T15:05:59.408Z",
+    "lastMeterReading": 161237,
+    "meterReadingPeriod": 60,
+    "intensity": {
+        "R": 20.1,
+        "S": 14.4,
+        "T": 22
+    },
+    "reactivePower": {
         "R": 45,
         "S": 43.5,
         "T": 42
-      },
-      "workingMode": "automatic"
-    }
+    },
+    "workingMode": "automatic"
+}
 ```
 
 ## Test it with a real service

--- a/specs/StreetLighting/StreetlightGroup/doc/spec.md
+++ b/specs/StreetLighting/StreetlightGroup/doc/spec.md
@@ -164,60 +164,42 @@ Normalized NGSI response
     "type": "StreetlightGroup",
     "circuitId": {
         "value": "C-456-A467"
-    }, 
+    },
     "powerState": {
         "value": "on"
-    }, 
+    },
     "dateLastSwitchingOn": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-07-07T19:59:06.618Z"
-    }, 
+    },
     "refStreetlightCabinetController": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "cabinetcontroller:CC45A34"
-    }, 
+    },
     "dateLastSwitchingOff": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-07-07T07:59:06.618Z"
-    }, 
+    },
     "switchingOnHours": {
         "value": [
             {
-                "hours": "Mo,Su 16:00-02:00", 
-                "to": "--01-07", 
-                "from": "--11-30", 
+                "hours": "Mo,Su 16:00-02:00",
+                "to": "--01-07",
+                "from": "--11-30",
                 "description": "Christmas"
             }
         ]
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "MultiLineString", 
+            "type": "MultiLineString",
             "coordinates": [
-                [
-                    [
-                        100.0, 
-                        0.0
-                    ], 
-                    [
-                        101.0, 
-                        1.0
-                    ]
-                ], 
-                [
-                    [
-                        102.0, 
-                        2.0
-                    ], 
-                    [
-                        103.0, 
-                        3.0
-                    ]
-                ]
+                [[100.0, 0.0], [101.0, 1.0]],
+                [[102.0, 2.0], [103.0, 3.0]]
             ]
         }
-    }, 
+    },
     "areaServed": {
         "value": "Calle Comercial Centro"
     }
@@ -229,31 +211,31 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "streetlightgroup:mycity:A12",
-      "type": "StreetlightGroup",
-      "location": {
+{
+    "id": "streetlightgroup:mycity:A12",
+    "type": "StreetlightGroup",
+    "location": {
         "type": "MultiLineString",
         "coordinates": [
-          [ [100.0, 0.0], [101.0, 1.0] ],
-          [ [102.0, 2.0], [103.0, 3.0] ]
+            [[100.0, 0.0], [101.0, 1.0]],
+            [[102.0, 2.0], [103.0, 3.0]]
         ]
-      },
-      "powerState": "on",
-      "areaServed": "Calle Comercial Centro",
-      "circuitId": "C-456-A467",
-      "dateLastSwitchingOn":  "2016-07-07T19:59:06.618Z",
-      "dateLastSwitchingOff": "2016-07-07T07:59:06.618Z",
-      "refStreetlightCabinetController": "cabinetcontroller:CC45A34",
-      "switchingOnHours": [
+    },
+    "powerState": "on",
+    "areaServed": "Calle Comercial Centro",
+    "circuitId": "C-456-A467",
+    "dateLastSwitchingOn": "2016-07-07T19:59:06.618Z",
+    "dateLastSwitchingOff": "2016-07-07T07:59:06.618Z",
+    "refStreetlightCabinetController": "cabinetcontroller:CC45A34",
+    "switchingOnHours": [
         {
-          "from" :  "--11-30",
-          "to" :    "--01-07",
-          "hours" : "Mo,Su 16:00-02:00",
-          "description": "Christmas"
+            "from": "--11-30",
+            "to": "--01-07",
+            "hours": "Mo,Su 16:00-02:00",
+            "description": "Christmas"
         }
-      ]
-    }
+    ]
+}
 ```
 
 ## Test it with a real service

--- a/specs/StreetLighting/StreetlightModel/doc/spec.md
+++ b/specs/StreetLighting/StreetlightModel/doc/spec.md
@@ -210,43 +210,41 @@ Normalized NGSI response
     "id": "streetlightmodel:TubularNumana:ASR42CG:HPS:100",
     "type": "StreetlightModel",
     "category": {
-        "value": [
-            "postTop"
-        ]
-    }, 
+        "value": ["postTop"]
+    },
     "colorRenderingIndex": {
         "value": 25
-    }, 
+    },
     "columnColor": {
         "value": "green"
-    }, 
+    },
     "name": {
         "value": "Tubular Numana 6M - ASR42CG - Son-T 100"
-    }, 
+    },
     "powerConsumption": {
         "value": 100
-    }, 
+    },
     "lanternManufacturerName": {
         "value": "Indal WRTL"
-    }, 
+    },
     "luminousFlux": {
         "value": 2300
-    }, 
+    },
     "lampTechnology": {
         "value": "HPS"
-    }, 
+    },
     "colorTemperature": {
         "value": 3000
-    }, 
+    },
     "lanternModelName": {
         "value": "ASR42CG"
-    }, 
+    },
     "columnModelName": {
         "value": "01 TUBULAR P/T 6M NUMANA"
-    }, 
+    },
     "lampModelName": {
         "value": "SON-T"
-    }, 
+    },
     "lampBrandName": {
         "value": "Philips"
     }
@@ -258,23 +256,23 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "streetlightmodel:TubularNumana:ASR42CG:HPS:100",
-      "type": "StreetlightModel",
-      "name": "Tubular Numana 6M - ASR42CG - Son-T 100",
-      "columnModelName": "01 TUBULAR P/T 6M NUMANA",
-      "columnColor": "green",
-      "lanternModelName": "ASR42CG",
-      "lanternManufacturerName": "Indal WRTL",
-      "lampModelName": "SON-T",
-      "lampBrandName": "Philips",
-      "lampTechnology": "HPS",
-      "powerConsumption": 100,
-      "colorTemperature": 3000,
-      "colorRenderingIndex": 25,
-      "luminousFlux": 2300,
-      "category": ["postTop"]
-    }
+{
+    "id": "streetlightmodel:TubularNumana:ASR42CG:HPS:100",
+    "type": "StreetlightModel",
+    "name": "Tubular Numana 6M - ASR42CG - Son-T 100",
+    "columnModelName": "01 TUBULAR P/T 6M NUMANA",
+    "columnColor": "green",
+    "lanternModelName": "ASR42CG",
+    "lanternManufacturerName": "Indal WRTL",
+    "lampModelName": "SON-T",
+    "lampBrandName": "Philips",
+    "lampTechnology": "HPS",
+    "powerConsumption": 100,
+    "colorTemperature": 3000,
+    "colorRenderingIndex": 25,
+    "luminousFlux": 2300,
+    "category": ["postTop"]
+}
 ```
 
 ## Test it with a real service

--- a/specs/Transportation/Bike/BikeHireDockingStation/doc/spec.md
+++ b/specs/Transportation/Bike/BikeHireDockingStation/doc/spec.md
@@ -31,14 +31,14 @@ A JSON Schema corresponding to this data model can be found
 
     -   Attribute type: [DateTime](https://schema.org/DateTime)
     -   Normative References:
-        [http://schema.org/DateTime](http://schema.org/DateTime)[ ](http://schema.org/DateTime)
+        [http://schema.org/DateTime](http://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
 -   `dateModified` : Last update timestamp of this entity.
 
     -   Attribute type: [DateTime](https://schema.org/DateTime)
     -   Normative References:
-        [http://schema.org/DateTime](http://schema.org/DateTime)[ ](http://schema.org/DateTime)
+        [http://schema.org/DateTime](http://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
 -   `location` : Geolocation of the station represented by a GeoJSON

--- a/specs/Transportation/EVChargingStation/doc/spec.md
+++ b/specs/Transportation/EVChargingStation/doc/spec.md
@@ -188,7 +188,8 @@ A JSON Schema corresponding to this data model can be found
     -   Optional
 
 -   `acceptedPaymentMethod` : Accepted payment method(s).
-    -   Normative references: https://schema.org/acceptedPaymentMethod
+    -   Normative references:
+        [https://schema.org/acceptedPaymentMethod](https://schema.org/acceptedPaymentMethod)
     -   Optional
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this
@@ -201,7 +202,6 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 ### Normalized Example
 
 Normalized NGSI response
-
 
 ```json
 {
@@ -289,6 +289,6 @@ T.B.D.
 
 ## See also
 
--   https://openchargemap.org/
--   https://wiki.openstreetmap.org/wiki/Tag:amenity=charging_station
--   https://www.plugshare.com/
+-   [https://openchargemap.org/](https://openchargemap.org/)
+-   [https://wiki.openstreetmap.org/wiki/Tag:amenity=charging_station](https://wiki.openstreetmap.org/wiki/Tag:amenity=charging_station)
+-   [https://www.plugshare.com/](https://wiki.openstreetmap.org/wiki/Tag:amenity=charging_station)

--- a/specs/Transportation/Road/doc/spec.md
+++ b/specs/Transportation/Road/doc/spec.md
@@ -65,8 +65,8 @@ The data model is defined as shown below:
 -   `roadClass` : The classification of this road.
 
     -   Attribute type: [Text](https://schema.org/Text)
-    -   Allowed values: Those described by
-        [http://wiki.openstreetmap.org/wiki/Key:highway](OpenStreetMap).
+    -   Allowed values: Those described by [OpenStreetMap]
+        (http://wiki.openstreetmap.org/wiki/Key:highway).
     -   Mandatory
 
 -   `refRoadSegment` : Road segments which define this road.

--- a/specs/Transportation/Road/doc/spec.md
+++ b/specs/Transportation/Road/doc/spec.md
@@ -77,9 +77,10 @@ The data model is defined as shown below:
 
 -   `location` : A GeoJSON (multi)line string which defines this road.
 
-    -   Normative References:  [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
+    -   Normative References:
+        [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     -   Attribute type: `geo:json`
-    -   Mandatory if `refRoadSegment` is not defined  
+    -   Mandatory if `refRoadSegment` is not defined
 
 -   `length` : Total length of this road in kilometers.
 
@@ -109,27 +110,27 @@ Normalized NGSI response
     "id": "Spain-Road-A62",
     "type": "Road",
     "refRoadSegment": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": [
-            "Spain-RoadSegment-A62-0-355-forwards", 
+            "Spain-RoadSegment-A62-0-355-forwards",
             "Spain-RoadSegment-A62-0-355-backwards"
         ]
-    }, 
+    },
     "roadClass": {
         "value": "motorway"
-    }, 
+    },
     "description": {
         "value": "Autov\u00eda de Castilla"
-    }, 
+    },
     "responsible": {
         "value": "Ministerio de Fomento - Gobierno de Espa\u00f1a"
-    }, 
+    },
     "length": {
         "value": 355
-    }, 
+    },
     "alternateName": {
         "value": "E-80"
-    }, 
+    },
     "name": {
         "value": "A-62"
     }
@@ -141,18 +142,20 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-        "id": "Spain-Road-A62",
-        "type": "Road",
-        "name": "A-62",
-        "alternateName": "E-80",
-        "description": "Autovía de Castilla",
-        "roadClass": "motorway",
-        "length": 355,
-        "refRoadSegment": ["Spain-RoadSegment-A62-0-355-forwards",
-                           "Spain-RoadSegment-A62-0-355-backwards"],
-        "responsible": "Ministerio de Fomento - Gobierno de España"
-    }
+{
+    "id": "Spain-Road-A62",
+    "type": "Road",
+    "name": "A-62",
+    "alternateName": "E-80",
+    "description": "Autovía de Castilla",
+    "roadClass": "motorway",
+    "length": 355,
+    "refRoadSegment": [
+        "Spain-RoadSegment-A62-0-355-forwards",
+        "Spain-RoadSegment-A62-0-355-backwards"
+    ],
+    "responsible": "Ministerio de Fomento - Gobierno de España"
+}
 ```
 
 ## Use it with a real service

--- a/specs/Transportation/RoadSegment/doc/spec.md
+++ b/specs/Transportation/RoadSegment/doc/spec.md
@@ -216,84 +216,55 @@ Normalized NGSI response
     "type": "RoadSegment",
     "category": {
         "value": "oneway"
-    }, 
+    },
     "endPoint": {
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -4.55167335377909, 
-                41.8570461783071
-            ]
+            "type": "Point",
+            "coordinates": [-4.55167335377909, 41.8570461783071]
         }
-    }, 
+    },
     "name": {
         "value": "Valladolid-Due\u00f1as"
-    }, 
+    },
     "startPoint": {
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -4.7299180606009, 
-                41.6844918725019
-            ]
+            "type": "Point",
+            "coordinates": [-4.7299180606009, 41.6844918725019]
         }
-    }, 
+    },
     "allowedVehicleType": {
-        "value": [
-            "car", 
-            "bus", 
-            "lorry", 
-            "trailer", 
-            "tanker", 
-            "van", 
-            "caravan"
-        ]
-    }, 
+        "value": ["car", "bus", "lorry", "trailer", "tanker", "van", "caravan"]
+    },
     "source": {
         "value": "http://wwww.openstreetmap.org"
-    }, 
+    },
     "totalLaneNumber": {
         "value": 2
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "LineString", 
+            "type": "LineString",
             "coordinates": [
-                [
-                    -4.7299180606009, 
-                    41.6844918725019
-                ], 
-                [
-                    -4.72855890957602, 
-                    41.6860596957855
-                ], 
-                [
-                    -4.5520357341647, 
-                    41.8569278186523
-                ], 
-                [
-                    -4.55167335377909, 
-                    41.8570461783071
-                ]
+                [-4.7299180606009, 41.6844918725019],
+                [-4.72855890957602, 41.6860596957855],
+                [-4.5520357341647, 41.8569278186523],
+                [-4.55167335377909, 41.8570461783071]
             ]
         }
-    }, 
+    },
     "minimumAllowedSpeed": {
         "value": 60
-    }, 
+    },
     "refRoad": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "Spain-Road-A62"
-    }, 
+    },
     "maximumAllowedSpeed": {
         "value": 120
-    }, 
+    },
     "laneUsage": {
-        "value": [
-            "forward", 
-            "forward"
-        ]
+        "value": ["forward", "forward"]
     }
 }
 ```
@@ -316,33 +287,30 @@ points just to make the example shorter.
     "maximumAllowedSpeed": 120,
     "minimumAllowedSpeed": 60,
     "startPoint": {
-      "type": "Point",
-      "coordinates": [-4.7299180606009, 41.6844918725019]
+        "type": "Point",
+        "coordinates": [-4.7299180606009, 41.6844918725019]
     },
     "endPoint": {
-      "type": "Point",
-      "coordinates": [-4.55167335377909, 41.8570461783071]
+        "type": "Point",
+        "coordinates": [-4.55167335377909, 41.8570461783071]
     },
     "allowedVehicleType": [
-        "car", "bus", "lorry", "trailer",
-        "tanker", "van", "caravan"
+        "car",
+        "bus",
+        "lorry",
+        "trailer",
+        "tanker",
+        "van",
+        "caravan"
     ],
     "location": {
-       "type": "LineString",
-       "coordinates": [
-            [
-               -4.7299180606009, 41.6844918725019
-            ],
-            [
-              -4.72855890957602, 41.6860596957855
-            ],
-            [
-              -4.5520357341647, 41.8569278186523
-            ],
-            [
-               -4.55167335377909, 41.8570461783071
-            ]
-       ]
+        "type": "LineString",
+        "coordinates": [
+            [-4.7299180606009, 41.6844918725019],
+            [-4.72855890957602, 41.6860596957855],
+            [-4.5520357341647, 41.8569278186523],
+            [-4.55167335377909, 41.8570461783071]
+        ]
     },
     "laneUsage": ["forward", "forward"],
     "source": "http://wwww.openstreetmap.org"

--- a/specs/Transportation/TrafficFlowObserved/doc/spec.md
+++ b/specs/Transportation/TrafficFlowObserved/doc/spec.md
@@ -231,41 +231,35 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-```
-    {
-       "id": "TrafficFlowObserved-Valladolid-osm-60821110",
-       "type": "TrafficFlowObserved",
-       "laneId": 1,
-       "address": {
-         "streetAddress": "Avenida de Salamanca",
-         "addressLocality": "Valladolid",
-         "addressCountry": "ES"
-       },
-       "location": {
-         "type": "LineString",
-         "coordinates": [
-           [
-             -4.73735395519672, 41.6538181849672
-           ],
-           [
-             -4.73414858659993, 41.6600594193478
-           ],
-           [
-             -4.73447575302641, 41.659585195093
-           ]
-         ]
-       },
-       "dateObserved": "2016-12-07T11:10:00/2016-12-07T11:15:00",
-       "dateObservedFrom": "2016-12-07T11:10:00Z",
-       "dateObservedTo": "2016-12-07T11:15:00Z",
-       "averageHeadwayTime": 0.5,
-       "intensity": 197,
-       "occupancy": 0.76,
-       "averageVehicleSpeed": 52.6,
-       "averageVehicleLength": 9.87,
-       "reversedLane": false,
-       "laneDirection": "forward"
-    }
+```json
+{
+    "id": "TrafficFlowObserved-Valladolid-osm-60821110",
+    "type": "TrafficFlowObserved",
+    "laneId": 1,
+    "address": {
+        "streetAddress": "Avenida de Salamanca",
+        "addressLocality": "Valladolid",
+        "addressCountry": "ES"
+    },
+    "location": {
+        "type": "LineString",
+        "coordinates": [
+            [-4.73735395519672, 41.6538181849672],
+            [-4.73414858659993, 41.6600594193478],
+            [-4.73447575302641, 41.659585195093]
+        ]
+    },
+    "dateObserved": "2016-12-07T11:10:00/2016-12-07T11:15:00",
+    "dateObservedFrom": "2016-12-07T11:10:00Z",
+    "dateObservedTo": "2016-12-07T11:15:00Z",
+    "averageHeadwayTime": 0.5,
+    "intensity": 197,
+    "occupancy": 0.76,
+    "averageVehicleSpeed": 52.6,
+    "averageVehicleLength": 9.87,
+    "reversedLane": false,
+    "laneDirection": "forward"
+}
 ```
 
 ## Use it with a real service

--- a/specs/UrbanMobility/AccessPoint/doc/spec.md
+++ b/specs/UrbanMobility/AccessPoint/doc/spec.md
@@ -93,7 +93,6 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-
 ```json
 {
     "id": "urn:ngsi-ld:AccessPoint:Madrid:acc_4_1_3",

--- a/specs/UrbanMobility/Agency/doc/spec.md
+++ b/specs/UrbanMobility/Agency/doc/spec.md
@@ -105,7 +105,6 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:Agency:Malaga_EMT",

--- a/specs/UrbanMobility/CalendarDateRule/doc/spec.md
+++ b/specs/UrbanMobility/CalendarDateRule/doc/spec.md
@@ -97,7 +97,6 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-
 ```json
 {
     "id": "urn:ngsi-ld:CalendarDateRule:Malaga:Rule67",

--- a/specs/UrbanMobility/Route/doc/spec.md
+++ b/specs/UrbanMobility/Route/doc/spec.md
@@ -121,7 +121,6 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:Route:Spain:Malaga:1",

--- a/specs/UrbanMobility/Service/doc/spec.md
+++ b/specs/UrbanMobility/Service/doc/spec.md
@@ -84,7 +84,6 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-
 ```json
 {
     "id": "urn:ngsi-ld:Service:Malaga:LAB",

--- a/specs/UrbanMobility/Stop/doc/spec.md
+++ b/specs/UrbanMobility/Stop/doc/spec.md
@@ -63,7 +63,7 @@ The data model is defined as shown below:
     -   Optional
 
 -   `location`: Stop's location encoded as GeoJSON Point which coordinates shall
-    be in the form [`stop_long`,`stop_lat`].
+    be in the form \[`stop_long`,`stop_lat`\].
 
     -   Attribute type: GeoProperty. `geo:json`.
     -   Normative References: [rfc7946](https://tools.ietf.org/html/rfc7946)
@@ -132,7 +132,6 @@ Normalized NGSI response
 ### key-value pairs Example
 
 Sample uses simplified representation for data consumers `?options=keyValues`
-
 
 ```json
 {

--- a/specs/UrbanMobility/StopTime/doc/spec.md
+++ b/specs/UrbanMobility/StopTime/doc/spec.md
@@ -129,7 +129,6 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-
 ```json
 {
     "id": "urn:ngsi-ld:gtfs:StopTime:Spain:Madrid:EMT:FE0010011_737",

--- a/specs/User/Activity/doc/spec.md
+++ b/specs/User/Activity/doc/spec.md
@@ -100,24 +100,24 @@ Normalized NGSI response
     "type": "UserActivity",
     "description": {
         "value": "User1 drive Car1 to Office1"
-    }, 
+    },
     "refTarget": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "Office1"
-    }, 
+    },
     "activityType": {
         "value": "Drive"
-    }, 
+    },
     "dateActivityStarted": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-11-30T07:00:00.00Z"
-    }, 
+    },
     "refAgent": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "User1"
-    }, 
+    },
     "refObject": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "Car1"
     }
 }

--- a/specs/User/UserContext/README.md
+++ b/specs/User/UserContext/README.md
@@ -11,19 +11,16 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```json
 {
-  "id": "UserContext1",
-  "type": "UserContext",
-  "location": {
-    "type": "Point",
-    "coordinates": [
-      -4.754444444,
-      41.640833333
-    ]
-  },
-  "refActivity": "UserActivity1",
-  "refUserDevice": "Device1",
-  "refUser": "User1"
+    "id": "UserContext1",
+    "type": "UserContext",
+    "location": {
+        "type": "Point",
+        "coordinates": [-4.754444444, 41.640833333]
+    },
+    "refActivity": "UserActivity1",
+    "refUserDevice": "Device1",
+    "refUser": "User1"
 }
 ```

--- a/specs/User/UserContext/doc/spec.md
+++ b/specs/User/UserContext/doc/spec.md
@@ -58,16 +58,16 @@ A JSON Schema corresponding to this data model can be found
     -   Mandatory if `location` is not present.
 
 -   `refUserDevice` : An object representing the current device used by the
-    User. See [Device](../../Device/Device/doc/spec.md) definition.
+    User. See [Device](../../../Device/Device/doc/spec.md) definition.
 
     -   Attribute type: A references to a
-        [Device](../../Device/Device/doc/spec.md) entity.
+        [Device](../../../Device/Device/doc/spec.md) entity.
     -   Optional
 
 -   `refActivity` : An object representing the current activity performed by the
-    User. See [UserActivity](../UserActivity/doc/spec.md) definition.
+    User. See [UserActivity](../../Activity/doc/spec.md) definition.
     -   Attribute type: A references to a
-        [UserActivity](../UserActivity/doc/spec.md) entity.
+        [UserActivity](../../Activity/doc/spec.md) entity.
     -   Optional
 
 **Note**: JSON Schemas only capture the NGSI simplified representation, this

--- a/specs/User/UserContext/doc/spec.md
+++ b/specs/User/UserContext/doc/spec.md
@@ -86,25 +86,22 @@ Normalized NGSI response
     "id": "UserContext1",
     "type": "UserContext",
     "refActivity": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "UserActivity1"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -4.754444444, 
-                41.640833333
-            ]
+            "type": "Point",
+            "coordinates": [-4.754444444, 41.640833333]
         }
-    }, 
+    },
     "refUser": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "User1"
-    }, 
+    },
     "refUserDevice": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "Device1"
     }
 }
@@ -116,18 +113,15 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
 {
-  "id": "UserContext1",
-  "type": "UserContext",
-  "location": {
-    "type": "Point",
-    "coordinates": [
-      -4.754444444,
-      41.640833333
-    ]
-  },
-  "refActivity": "UserActivity1",
-  "refUserDevice": "Device1",
-  "refUser": "User1"
+    "id": "UserContext1",
+    "type": "UserContext",
+    "location": {
+        "type": "Point",
+        "coordinates": [-4.754444444, 41.640833333]
+    },
+    "refActivity": "UserActivity1",
+    "refUserDevice": "Device1",
+    "refUser": "User1"
 }
 ```
 

--- a/specs/WasteManagement/WasteContainer/doc/spec.md
+++ b/specs/WasteManagement/WasteContainer/doc/spec.md
@@ -56,7 +56,7 @@ A JSON Schema corresponding to this data model can be found
                 production environmments where the attribute type is equal to
                 the `ISO8601` string. If so, it must be considered as a synonym
                 of `DateTime`.
-    -   Allowed values: Interval [0,1].
+    -   Allowed values: Interval \[0,1\].
     -   Optional
 
 -   `fullnessThreshold` : The level at which the container will generate a
@@ -77,7 +77,7 @@ A JSON Schema corresponding to this data model can be found
                 production environmments where the attribute type is equal to
                 the `ISO8601` string. If so, it must be considered as a synonym
                 of `DateTime`.
-    -   Allowed values: Interval [0,1].
+    -   Allowed values: Interval \[0,1\].
     -   Optional
 
 -   `cargoWeight` : Weight of the container load.
@@ -364,47 +364,40 @@ Normalized NGSI response
     "type": "WasteContainer",
     "status": {
         "value": "ok"
-    }, 
+    },
     "category": {
-        "value": [
-            "underground"
-        ]
-    }, 
+        "value": ["underground"]
+    },
     "dateLastEmptying": {
-        "type": "DateTime", 
+        "type": "DateTime",
         "value": "2016-06-21T15:05:59.408Z"
-    }, 
+    },
     "serialNumber": {
         "value": "ab56kjl"
-    }, 
+    },
     "nextActuationDeadline": {
         "value": "2016-06-28T15:05:59.408Z"
-    }, 
+    },
     "refWasteContainerIsle": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "wastecontainerisle:Fleming:12"
-    }, 
+    },
     "refDevice": {
-        "type": "Relationship", 
-        "value": [
-            "device-Fleming:12a:1"
-        ]
-    }, 
+        "type": "Relationship",
+        "value": ["device-Fleming:12a:1"]
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Point", 
-            "coordinates": [
-                -3.164485591715449, 
-                40.62785133667262
-            ]
+            "type": "Point",
+            "coordinates": [-3.164485591715449, 40.62785133667262]
         }
-    }, 
+    },
     "fillingLevel": {
         "value": 0.4
-    }, 
+    },
     "refWasteContainerModel": {
-        "type": "Relationship", 
+        "type": "Relationship",
         "value": "wastecontainermodel:c1"
     }
 }
@@ -415,23 +408,23 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-       "id": "wastecontainer:Fleming:12a",
-       "type": "WasteContainer",
-       "refWasteContainerModel": "wastecontainermodel:c1",
-       "refWasteContainerIsle":  "wastecontainerisle:Fleming:12",
-       "serialNumber": "ab56kjl",
-       "location": {
-         "type": "Point",
-         "coordinates": [  -3.164485591715449, 40.62785133667262 ]
-       },
-       "fillingLevel" : 0.4,
-       "dateLastEmptying": "2016-06-21T15:05:59.408Z",
-       "nextActuationDeadline": "2016-06-28T15:05:59.408Z",
-       "status": "ok",
-       "category": ["underground"],
-       "refDevice": ["device-Fleming:12a:1"]
-    }
+{
+    "id": "wastecontainer:Fleming:12a",
+    "type": "WasteContainer",
+    "refWasteContainerModel": "wastecontainermodel:c1",
+    "refWasteContainerIsle": "wastecontainerisle:Fleming:12",
+    "serialNumber": "ab56kjl",
+    "location": {
+        "type": "Point",
+        "coordinates": [-3.164485591715449, 40.62785133667262]
+    },
+    "fillingLevel": 0.4,
+    "dateLastEmptying": "2016-06-21T15:05:59.408Z",
+    "nextActuationDeadline": "2016-06-28T15:05:59.408Z",
+    "status": "ok",
+    "category": ["underground"],
+    "refDevice": ["device-Fleming:12a:1"]
+}
 ```
 
 ## Test it with real services

--- a/specs/WasteManagement/WasteContainerIsle/doc/spec.md
+++ b/specs/WasteManagement/WasteContainerIsle/doc/spec.md
@@ -106,58 +106,38 @@ Normalized NGSI response
     "id": "wastecontainerisle:Fleming:12",
     "type": "WasteContainerIsle",
     "refWasteContainer": {
-        "type": "Relationship", 
-        "value": [
-            "wastecontainer:Fleming:12a", 
-            "wastecontainer:Fleming:12b"
-        ]
-    }, 
+        "type": "Relationship",
+        "value": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"]
+    },
     "features": {
-        "value": [
-            "underground"
-        ]
-    }, 
+        "value": ["underground"]
+    },
     "description": {
         "value": "Container isle located downtown"
-    }, 
+    },
     "location": {
-        "type": "geo:json", 
+        "type": "geo:json",
         "value": {
-            "type": "Polygon", 
+            "type": "Polygon",
             "coordinates": [
                 [
-                    [
-                        -3.164485591715449, 
-                        40.62785133667262
-                    ], 
-                    [
-                        -3.164445130316209, 
-                        40.62787156737224
-                    ], 
-                    [
-                        -3.164394553567159, 
-                        40.62777209976578
-                    ], 
-                    [
-                        -3.164424899616589, 
-                        40.62775018317452
-                    ], 
-                    [
-                        -3.164485591715449, 
-                        40.62785133667262
-                    ]
+                    [-3.164485591715449, 40.62785133667262],
+                    [-3.164445130316209, 40.62787156737224],
+                    [-3.164394553567159, 40.62777209976578],
+                    [-3.164424899616589, 40.62775018317452],
+                    [-3.164485591715449, 40.62785133667262]
                 ]
             ]
         }
-    }, 
+    },
     "address": {
-        "type": "PostalAddress", 
+        "type": "PostalAddress",
         "value": {
-            "addressLocality": "Guadalajara", 
-            "addressCountry": "ES", 
+            "addressLocality": "Guadalajara",
+            "addressCountry": "ES",
             "streetAddress": "Calle Dr. Fleming, 12"
         }
-    }, 
+    },
     "name": {
         "value": "Dr. Fleming 12, Esquina Manuel Paez Xaramillo"
     }
@@ -169,31 +149,31 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-      "id": "wastecontainerisle:Fleming:12",
-      "type": "WasteContainerIsle",
-      "location": {
-         "type": "Polygon",
-         "coordinates": [
-          [
-            [ -3.164485591715449, 40.62785133667262 ],
-            [ -3.164445130316209, 40.627871567372239 ],
-            [ -3.164394553567159, 40.627772099765778 ],
-            [ -3.164424899616589, 40.62775018317452 ],
-            [ -3.164485591715449, 40.62785133667262 ]
-          ]
-         ]
-      },
-      "address": {
-         "streetAddress" : "Calle Dr. Fleming, 12",
-         "addressLocality": "Guadalajara",
-         "addressCountry": "ES"
-      },
-      "features": ["underground"],
-      "name": "Dr. Fleming 12, Esquina Manuel Paez Xaramillo",
-      "description": "Container isle located downtown",
-      "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"]
-    }
+{
+    "id": "wastecontainerisle:Fleming:12",
+    "type": "WasteContainerIsle",
+    "location": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-3.164485591715449, 40.62785133667262],
+                [-3.164445130316209, 40.627871567372239],
+                [-3.164394553567159, 40.627772099765778],
+                [-3.164424899616589, 40.62775018317452],
+                [-3.164485591715449, 40.62785133667262]
+            ]
+        ]
+    },
+    "address": {
+        "streetAddress": "Calle Dr. Fleming, 12",
+        "addressLocality": "Guadalajara",
+        "addressCountry": "ES"
+    },
+    "features": ["underground"],
+    "name": "Dr. Fleming 12, Esquina Manuel Paez Xaramillo",
+    "description": "Container isle located downtown",
+    "containers": ["wastecontainer:Fleming:12a", "wastecontainer:Fleming:12b"]
+}
 ```
 
 ## Test it with a real service

--- a/specs/WasteManagement/WasteContainerModel/doc/spec.md
+++ b/specs/WasteManagement/WasteContainerModel/doc/spec.md
@@ -181,44 +181,37 @@ Normalized NGSI response
     "id": "wastecontainermodel:c1",
     "type": "WasteContainerModel",
     "category": {
-        "value": [
-            "dumpster"
-        ]
-    }, 
+        "value": ["dumpster"]
+    },
     "cargoVolume": {
         "value": 150
-    }, 
+    },
     "modelName": {
         "value": "C1"
-    }, 
+    },
     "name": {
         "value": "Dumpster_Brute_2009_Plastic_Green"
-    }, 
+    },
     "compliantWith": {
-        "value": [
-            "UNE-EN 840-2:2013"
-        ]
-    }, 
+        "value": ["UNE-EN 840-2:2013"]
+    },
     "madeOf": {
         "value": "plastic"
-    }, 
+    },
     "height": {
         "value": 0.8
-    }, 
+    },
     "width": {
         "value": 0.5
-    }, 
+    },
     "depth": {
         "value": 0.4
-    }, 
+    },
     "brandName": {
         "value": "Brute"
-    }, 
+    },
     "features": {
-        "value": [
-            "wheels", 
-            "lid"
-        ]
+        "value": ["wheels", "lid"]
     }
 }
 ```
@@ -228,21 +221,21 @@ Normalized NGSI response
 Sample uses simplified representation for data consumers `?options=keyValues`
 
 ```json
-    {
-       "id": "wastecontainermodel:c1",
-       "type": "WasteContainerModel",
-       "name": "Dumpster_Plastic_Brute_2009",
-       "width": 0.50,
-       "height": 0.80,
-       "depth": 0.40,
-       "cargoVolume": 150,
-       "brandName": "Brute",
-       "modelName": "C1",
-       "compliantWith": ["UNE-EN 840-2:2013"],
-       "madeOf": "plastic",
-       "features": ["wheels", "lid"],
-       "category": ["dumpster"]
-    }
+{
+    "id": "wastecontainermodel:c1",
+    "type": "WasteContainerModel",
+    "name": "Dumpster_Plastic_Brute_2009",
+    "width": 0.5,
+    "height": 0.8,
+    "depth": 0.4,
+    "cargoVolume": 150,
+    "brandName": "Brute",
+    "modelName": "C1",
+    "compliantWith": ["UNE-EN 840-2:2013"],
+    "madeOf": "plastic",
+    "features": ["wheels", "lid"],
+    "category": ["dumpster"]
+}
 ```
 
 ## Test it with a real service

--- a/specs/Weather/WeatherAlert/README.md
+++ b/specs/Weather/WeatherAlert/README.md
@@ -1,7 +1,7 @@
 # Weather Alert
 
 This folder contains all the software artefacts to offer weather alert data in
-NGSIv2. The source of this data is the global
+NGSI v2. The source of this data is the global
 [European Weather Alarm Service](http://meteoalarm.eu).
 
 -   `meteoalarm_harvest.py`. A harvester for weather alarms throughout Europe.

--- a/specs/Weather/WeatherForecast/README.md
+++ b/specs/Weather/WeatherForecast/README.md
@@ -1,6 +1,6 @@
 # Weather Forecast
 
-This folder contains a set of scripts which allow to expose a NGSIv2 endpoint
+This folder contains a set of scripts which allow to expose a NGSI v2 endpoint
 intended to provide weather forecasts.
 
 Source of weather forecast are the

--- a/specs/Weather/WeatherObserved/README.md
+++ b/specs/Weather/WeatherObserved/README.md
@@ -1,24 +1,29 @@
 # Weather Observed
 
-The Weather observed in Spain is provided by [Spanish National Meteorology Agency](http://aemet.es), from Portugal
-by [Instituto Português do Mar e da Atmosfera](http://www.ipma.pt/pt). [Harvesters](./harvest) transform this data to NGSIv2.
+The Weather observed in Spain is provided by
+[Spanish National Meteorology Agency](http://aemet.es), from Portugal by
+[Instituto Português do Mar e da Atmosfera](http://www.ipma.pt/pt).
+[Harvesters](./harvest) transform this data to NGSIv2.
 
-[Harvester for Spain](./harvest/spain) requires the [list](../../PointOfInterest/WeatherStation) of stations.
+[Harvester for Spain](./harvest/spain) requires the
+[list](../../PointOfInterest/WeatherStation) of stations.
 
 This folder contains the following scripts:
 
 -   `weather_observed.py` .- Contains all the logic to expose the weather
     observed as an NGSIv2 data model (outdated).
--   `spain/harvester.py` .- Performs data harvesting using
-    AEMET's data site as the origin and Orion Context Broker as the destination.
--   `portugal/harvester.py` .- Performs data harvesting using
-    IPMA's data site as the origin and Orion Context Broker as the destination.
+-   `spain/harvester.py` .- Performs data harvesting using AEMET's data site as
+    the origin and Orion Context Broker as the destination.
+-   `portugal/harvester.py` .- Performs data harvesting using IPMA's data site
+    as the origin and Orion Context Broker as the destination.
 
-Please check data licenses at the original data sources before using this data in an application.
+Please check data licenses at the original data sources before using this data
+in an application.
 
 ## Public instance
 
-To get access to a public instance offering weather observed data please have a look at the
+To get access to a public instance offering weather observed data please have a
+look at the
 [GSMA's API Directory](http://apidirectory.connectedliving.gsma.com).
 
 The instance described
@@ -48,10 +53,7 @@ What was the weather observed today in Valladolid (Spain)?
         "dateObserved": "2019-01-10T19:00:00.00Z",
         "id": "Spain-WeatherObserved-2422-latest",
         "location": {
-            "coordinates": [
-                -4.754444444,
-                41.640833333
-            ],
+            "coordinates": [-4.754444444, 41.640833333],
             "type": "Point"
         },
         "precipitation": 0,

--- a/specs/Weather/WeatherObserved/README.md
+++ b/specs/Weather/WeatherObserved/README.md
@@ -3,7 +3,7 @@
 The Weather observed in Spain is provided by
 [Spanish National Meteorology Agency](http://aemet.es), from Portugal by
 [Instituto Português do Mar e da Atmosfera](http://www.ipma.pt/pt).
-[Harvesters](./harvest) transform this data to NGSIv2.
+[Harvesters](./harvest) transform this data to NGSI v2.
 
 [Harvester for Spain](./harvest/spain) requires the
 [list](../../PointOfInterest/WeatherStation) of stations.
@@ -11,7 +11,7 @@ The Weather observed in Spain is provided by
 This folder contains the following scripts:
 
 -   `weather_observed.py` .- Contains all the logic to expose the weather
-    observed as an NGSIv2 data model (outdated).
+    observed as an NGSI v2 data model (outdated).
 -   `spain/harvester.py` .- Performs data harvesting using AEMET's data site as
     the origin and Orion Context Broker as the destination.
 -   `portugal/harvester.py` .- Performs data harvesting using IPMA's data site

--- a/specs/guidelines.md
+++ b/specs/guidelines.md
@@ -82,7 +82,7 @@ section.
 
     which contains a reference to an entity of type `StreetlightModel`. This
     option has been extensively used by data models initially intended to be
-    used with NGSIv2 . + B/ Name the attribute using a verb (plus optionally an
+    used with NGSI v2 . + B/ Name the attribute using a verb (plus optionally an
     object) such as `hasStop`, `operatedBy`, `hasTrip`, etc. This option is the
     one advocated by NGSI-LD, as in NGSI-LD URNs are used to identify entities,
     and NGSI-LD URNs already convey the type of the target entity, for instance
@@ -105,7 +105,7 @@ be considered as the recommended one and A option is to some extent
     date.
 
 -   `dateCreated` and `dateModified` are special entity attributes provided
-    off-the-shelf by NGSIv2 implementations. Be careful because they can be
+    off-the-shelf by NGSI v2 implementations. Be careful because they can be
     different than the actual creation or update date of the real world entity
     represented by its corresponding digital entity.
 
@@ -122,7 +122,7 @@ be considered as the recommended one and A option is to some extent
     timestamp of a dynamic attribute. Please note that this is the actual date
     at which the measured value was obtained (from a sensor, by visual
     observation, etc.), and that date might be different than the date (metadata
-    attribute named `dateModified` as per NGSIv2) at which the attribute of the
+    attribute named `dateModified` as per NGSI v2) at which the attribute of the
     digital entity was updated, as typically there might be delay, specially on
     IoT networks which deliver data only at specific timeslots.
 

--- a/specs/howto.md
+++ b/specs/howto.md
@@ -309,16 +309,16 @@ available [here](https://tools.ietf.org/html/rfc7946#appendix-A).
 
 ### How to specify units of measurement
 
-1. If your data use the default unit defined in the Data Model, you don't need
-   to specify any. It is implied.
-1. Unless explicitly stated otherwise, all FIWARE data models use the metric
-   system of measurements by default. Regardless the model specification include
-   explicit reference to the scale adopted.
-1. If your data use a different unit, you will need to use the `unitCode`
-   metadata annotation in your data (and you will need to adopt the normalised
-   representation). Code used should be the ones defined by
-   [UN/CEFACT](https://www.unece.org/fileadmin/DAM/cefact/recommendations/rec20/rec20_rev3_Annex3e.pdf).
-   E.g.:
+1.  If your data use the default unit defined in the Data Model, you don't need
+    to specify any. It is implied.
+2.  Unless explicitly stated otherwise, all FIWARE data models use the metric
+    system of measurements by default. Regardless the model specification
+    include explicit reference to the scale adopted.
+3.  If your data use a different unit, you will need to use the `unitCode`
+    metadata annotation in your data (and you will need to adopt the normalised
+    representation). Code used should be the ones defined by
+    [UN/CEFACT](https://www.unece.org/fileadmin/DAM/cefact/recommendations/rec20/rec20_rev3_Annex3e.pdf).
+    E.g.:
 
 ```json
 "length": {

--- a/specs/ngsi-ld_howto.md
+++ b/specs/ngsi-ld_howto.md
@@ -53,7 +53,7 @@ instantiations of the FIWARE Data Models to NGSI-LD:
 
 The FIWARE Community has already provided a simple script to migrate FIWARE NGSI
 entity representations to NGSI-LD, see
-[https://github.com/Fiware/dataModels/blob/master/tools/normalized2LD.py]
+[normalized2LD.py](https://github.com/Fiware/dataModels/blob/master/tools/normalized2LD.py)
 
 ## Example of migration to NGSI-LD
 

--- a/validator/.textlintrc
+++ b/validator/.textlintrc
@@ -1,25 +1,198 @@
 {
   "rules": {
-    "terminology": true,
+    "terminology": {
+      "defaultTerms": false,
+     "terms": [
+        // Brands
+        "Airbnb",
+        "Android",
+        "AppleScript",
+        "AppVeyor",
+        "AVA",
+        "BrowserStack",
+        "Browsersync",
+        "Codecov",
+        "CodePen",
+        "CodeSandbox",
+        "DefinitelyTyped",
+        "EditorConfig",
+        "ESLint",
+        "FIWARE",
+        "GitHub",
+        "GraphQL",
+        "iOS",
+        "JavaScript",
+        "JetBrains",
+        "jQuery",
+        "LinkedIn",
+        "Lodash",
+        "MacBook",
+        "Markdown",
+        "OpenType",
+        "PayPal",
+        "PhpStorm",
+        "RubyMine",
+        "Sass",
+        "SemVer",
+        "TypeScript",
+        "UglifyJS",
+        "WebStorm",
+        "WordPress",
+        "YouTube",
+        ["JSDocs?", "JSDoc"],
+//        ["Node(?:js)?", "Node.js"],
+        ["React[ .]js", "React"],
+        ["SauceLabs", "Sauce Labs"],
+        ["StackOverflow", "Stack Overflow"],
+        ["styled ?components", "styled-components"],
+        ["HTTP[ /]2(?:\\.0)?", "HTTP/2"],
+        ["OS X", "macOS"],
+        ["Mac ?OS", "macOS"],
+        ["a npm", "an npm"],
+
+        // ECMAScript
+        "ECMAScript",
+        ["ES2015", "ES6"],
+        ["ES7", "ES2016"],
+
+        // Abbreviations
+        "3D",
+        ["3-D", "3D"],
+        "Ajax",
+        "API",
+        ["API['’]?s", "APIs"],
+        "CSS",
+        "GIF",
+        "HTML",
+        "HTTPS",
+        "IoT",
+        "I/O",
+        ["I-O", "I/O"],
+        "JPEG",
+        "MIME",
+        ["NGSIv2", "NGSI v2"],
+        "OK",
+        "PaaS",
+        "PDF",
+        "PNG",
+        "SaaS",
+        "URL",
+        ["URL['’]?s", "URLs"],
+        ["an URL", "a URL"],
+        ["wi[- ]?fi", "Wi-Fi"],
+
+        // Names
+        "McKenzie",
+        "McConnell",
+
+        // Words and phrases
+        "ID", // http://stackoverflow.com/questions/1151338/id-or-id-on-user-interface
+        ["id['’]?s", "IDs"],
+        ["backwards compatible", "backward compatible"],
+        ["build system(s?)", "build tool$1"],
+        ["CLI tool(s?)", "command-line tool$1"],
+        ["he or she", "they"],
+        ["he/she", "they"],
+        ["\\(s\\)he", "they"],
+        ["repo\\b", "repository"],
+        ["smartphone(s?)", "mobile phone$1"],
+        ["web[- ]?site(s?)", "site$1"],
+
+        // Single word
+        ["auto[- ]complete", "autocomplete"],
+        ["auto[- ]format", "autoformat"],
+        ["auto[- ]fix", "autofix"],
+        ["auto[- ]fixing", "autofixing"],
+        ["back[- ]end(\\w*)", "backend$1"],
+        ["bug[- ]fix(es?)", "bugfix$1"],
+        ["check[- ]box(es?)", "checkbox$1"],
+        ["code[- ]base(es?)", "codebase$1"],
+        ["co[- ]locate(d?)", "colocate$1"],
+        ["end[- ]point(s?)", "endpoint$1"],
+        ["e[- ]mail(s?)", "email$1"],
+        ["file[- ]name(s?)", "filename$1"],
+        ["front[- ]end(\\w*)", "frontend$1"],
+        ["hack[- ]a[- ]thon(s?)", "hackathon$1"],
+        ["host[- ]name(s?)", "hostname$1"],
+        ["hot[- ]key(s?)", "hotkey$1"],
+        ["life[- ]cycle", "lifecycle"],
+        ["life[- ]stream(s?)", "lifestream$1"],
+        ["lock[- ]file(s?)", "lockfile$1"],
+        ["mark-up", "markup"], // “mark up” as a verb is OK
+        ["meta[- ]data", "metadata"],
+        ["name[- ]space(s?)", "namespace$1"],
+        ["pre[- ]condition(s?)", "precondition$1"],
+        ["pre[- ]defined", "predefined"],
+        ["pre[- ]release(s?)", "prerelease$1"],
+        ["run[- ]time", "runtime"],
+        ["screen[- ]shot(s?)", "screenshot$1"],
+        ["screen[- ]?snap(s?)", "screenshot$1"],
+        ["sub[- ]class((?:es|ing)?)", "subclass$1"],
+        ["sub[- ]tree(s?)", "subtree$1"],
+        ["time[- ]stamp(s?)", "timestamp$1"],
+        ["touch[- ]screen(s?)", "touchscreen$1"],
+        ["user[- ]name(s?)", "username$1"],
+        ["walk[- ]through", "walkthrough"],
+        ["white[- ]space", "whitespace"],
+        ["wild[- ]card(s?)", "wildcard$1"],
+
+        // Multiple words
+        ["change-?log(s?)", "change log$1"],
+        ["css-?in-?js", "CSS in JS"],
+        ["code-?review(s?)", "code review$1"],
+        ["code-?splitting", "code splitting"],
+        ["end-?user(s?)", "end user$1"],
+        ["file-?type(s?)", "file type$1"],
+        ["open-?source(ed?)", "open source$1"],
+        ["regexp?(s?)", "regular expression$1"],
+        ["style-?guide(s?)", "style guide$1"],
+        ["tree-?shaking", "tree shaking"],
+        ["source-?map(s?)", "source map$1"],
+        ["style-?sheet(s?)", "style sheet$1"],
+        ["user-?base", "user base"],
+        ["web-?page(s?)", "web page$1"],
+
+        // Hyphenated
+        ["built ?in", "built-in"],
+        ["client ?side", "client-side"],
+        ["command ?line", "command-line"],
+        ["end ?to ?end", "end-to-end"],
+        ["error ?prone", "error-prone"],
+        ["higher ?order", "higher-order"],
+        ["key[/ ]?value", "key-value"],
+        ["server ?side", "server-side"],
+        ["two ?steps?", "two-step"],
+        ["2 ?steps?", "two-step"],
+
+        // Starts from a lower case letter in the middle of a sentence
+        ["(\\w+[^.?!]\\)? )base64", "$1base64"],
+        ["(\\w+[^.?!]\\)? )stylelint", "$1stylelint"],
+        ["(\\w+[^.?!]\\)? )webpack", "$1webpack"],
+        ["(\\w+[^.?!]\\)? )npm", "$1npm"],
+
+        // Typos
+        ["environemnt(s?)", "environment$1"],
+        ["pacakge(s?)", "package$1"],
+        ["tilda", "tilde"],
+        ["falsey", "falsy"]
+      ]
+    },
     "common-misspellings": true,
     "write-good": {
       "adverb": false,
       "passive": false,
       "tooWordy": false,
       "weasel": false,
-      "so": true
+      "so": false
     },
     "no-dead-link": {
-       "checkRelative": false,
        "ignoreRedirects": true,
        "ignore": [
           "mailto:*",
           "https://schema.org/*",
-          "http://schema.org/*"
+          "http://schema.org/*",
+          "https://www.tourspain.es/en-us"
       ]
     }
-  },
-  "filters": {
-    "comments": true
   }
 }

--- a/validator/README.md
+++ b/validator/README.md
@@ -41,7 +41,7 @@ Command-line available options are:
 
 -   `-i, --dmv:importSchemas`. Additional schemas that will be included during
     validation. Default imported schemas are: common-schema.json,
-    geometry-schema.json [array]
+    geometry-schema.json \[array\]
 -   `-w, --dmv:warnings`. How to handle FIWARE Data Models checks warnings.
     -   `true (default)` - print warnings, but does not fail.
     -   `ignore` - do nothing and do not print warnings.

--- a/validator/package.json
+++ b/validator/package.json
@@ -40,6 +40,8 @@
 		"lint-staged": "^7.3.0",
 		"memfs": "2.10.1",
 		"prettier": "^1.14.2",
+		"remark-cli": "^6.0.1",
+		"remark-preset-lint-recommended": "^3.0.2",
 		"textlint": "^11.0.1",
 		"textlint-filter-rule-comments": "^1.2.2",
 		"textlint-rule-common-misspellings": "^1.0.1",
@@ -53,6 +55,7 @@
 	"scripts": {
 		"lint": "eslint . --cache --fix",
 		"lint:text": "textlint  --fix '../README.md' 'README.md' '../specs/*.md' '../specs/**/*.md'",
+		"lint:md": "remark 'README.md' '../specs'",
 		"precommit": "lint-staged",
 		"prettier": "prettier --single-quote --trailing-comma es5 --write **/*.js *.js",
 		"prettier:text": "prettier '../*.md' '../specs/*.md' '../specs/**/*.md' --tab-width 4 --print-width 80 --write --prose-wrap always",

--- a/validator/package.json
+++ b/validator/package.json
@@ -54,7 +54,7 @@
 	},
 	"scripts": {
 		"lint": "eslint . --cache --fix",
-		"lint:text": "textlint  --fix '../README.md' 'README.md' '../specs/*.md' '../specs/**/*.md'",
+		"lint:text": "textlint '../README.md' 'README.md' '../specs/*.md' '../specs/**/*.md'",
 		"lint:md": "remark 'README.md' '../specs'",
 		"precommit": "lint-staged",
 		"prettier": "prettier --single-quote --trailing-comma es5 --write **/*.js *.js",


### PR DESCRIPTION
This PR verifies that prettier has been run over the changes and that the resultant Markdown doesn't contain any nasty surprises. 

[Remark](https://github.com/remarkjs/remark-lint) does the same job for markdown that eslint does for JavaScript - it  lints the resultant markdown and confirms that changes + prettier changes are good.

I have also updated the terminology list for the text lint to ensure that NSGI v2 and FIWARE are correctly used. I've  also removed Node from the terminology list as it results in false positives.