### PR TITLE
Feature/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: required
+dist: xenial
 cache: pip
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
          - node ./validator/validate.js -i common-schema.json -i geometry-schema.json -i specs/Weather/weather-schema.json -i specs/Alert/alert-schema.json -p specs -c true
 
     - stage: test
-      name: "Unit Tests 3.6"
-      python: 3.6
+      name: "Unit Tests 3.7"
+      python: 3.7
       node_js: 10
 
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,21 @@
 language: python
 cache: pip
-python:
-  - 2.7
-  - 3.6
-install:
-  - pip install flake8
-before_script:
-  # stop the build if there are Python syntax errors, PEP8 violations, undefined names
-  - flake8 . --count --select=E,F821,F822,F823 --max-line-length=127 --show-source --statistics
-  # exit-zero treats all errors as warnings.  GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-script:
-  - true  # add other tests here
 
-matrix:
+jobs:
   include:
-    - language: node_js
-      python:
-      node_js:
-        - 8
+    - stage: test
+      name: "Unit Tests 2.7"
+      python: 2.7
+      node_js: 10
+
+      before_install:
+        - pip install flake8
+        # stop the build if there are Python syntax errors, PEP8 violations, undefined names
+        - flake8 . --count --select=E,F821,F822,F823 --max-line-length=127 --show-source --statistics
+        # exit-zero treats all errors as warnings.  GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       install:
-      ## Data model validator
+        ## Data model validator
         - npm install -C ./validator
         - sudo apt-get remove -y docker docker-engine docker.io
         - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
@@ -32,12 +27,51 @@ matrix:
         - docker run -d --name orion1 --link mongodb:mongodb -p 1026:1026 fiware/orion -dbhost mongodb
       before_script:
         - npm run lint -C ./validator
+       
+      script:
+         - node ./validator/validate.js -i common-schema.json -i geometry-schema.json -i specs/Weather/weather-schema.json -i specs/Alert/alert-schema.json -p specs -c true
+         - npm test -C ./validator
+
+    - stage: test
+      name: "Unit Tests 3.6"
+      python: 3.6
+      node_js: 10
+
+      before_install:
+        - pip install flake8
+        # stop the build if there are Python syntax errors, PEP8 violations, undefined names
+        - flake8 . --count --select=E,F821,F822,F823 --max-line-length=127 --show-source --statistics
+        # exit-zero treats all errors as warnings.  GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      install:
+        ## Data model validator
+        - npm install -C ./validator
+        - sudo apt-get remove -y docker docker-engine docker.io
+        - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        - sudo apt-get -qq update
+        - sudo apt-get install -y docker-ce
+        - docker run --name mongodb -d mongo:3.4
+        - docker run -d --name orion1 --link mongodb:mongodb -p 1026:1026 fiware/orion -dbhost mongodb
+      before_script:
+        - npm run lint -C ./validator
+       
+      script:
+         - node ./validator/validate.js -i common-schema.json -i geometry-schema.json -i specs/Weather/weather-schema.json -i specs/Alert/alert-schema.json -p specs -c true
+         - npm test -C ./validator
+
+    - stage: test
+      name: "Documentation Tests"
+      language: node_js
+      node_js: 10
+
+      install:
+        - npm install -C ./validator
+
+      script:
         - npm run lint:md -C ./validator
         - npm run lint:text -C ./validator
-        - node ./validator/validate.js -i common-schema.json -i geometry-schema.json -i specs/Weather/weather-schema.json -i specs/Alert/alert-schema.json -p specs -c true
-        - npm test -C ./validator
-      script:
-        - true
 
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
        
       script:
          - node ./validator/validate.js -i common-schema.json -i geometry-schema.json -i specs/Weather/weather-schema.json -i specs/Alert/alert-schema.json -p specs -c true
-         - npm test -C ./validator
 
     - stage: test
       name: "Unit Tests 3.6"
@@ -59,7 +58,6 @@ jobs:
        
       script:
          - node ./validator/validate.js -i common-schema.json -i geometry-schema.json -i specs/Weather/weather-schema.json -i specs/Alert/alert-schema.json -p specs -c true
-         - npm test -C ./validator
 
     - stage: test
       name: "Documentation Tests"
@@ -72,6 +70,8 @@ jobs:
       script:
         - npm run lint:md -C ./validator
         - npm run lint:text -C ./validator
+
+
 
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
         - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         - sudo apt-get -qq update
         - sudo apt-get install -y docker-ce
-        - docker run --name mongodb -d mongo:3.4
+        - docker run --name mongodb -d mongo:3.6
         - docker run -d --name orion1 --link mongodb:mongodb -p 1026:1026 fiware/orion -dbhost mongodb
       before_script:
         - npm run lint -C ./validator

--- a/specs/Environment/AeroAllergenObserved/doc/spec.md
+++ b/specs/Environment/AeroAllergenObserved/doc/spec.md
@@ -96,10 +96,11 @@ The structure of such an attribute will be as follows:
 
 -   Attribute name: Equal to the name of the allergen, for instance `alnus`. A
     list of commonly used aero allergens in Europe can be found on
-    [polleninfo.org](https://www.polleninfo.org/en/allergy/profiles/alder.html) a web site
-    maintained by the European Aeroallergen Network. A World Health Organization
-    (WHO) Allergen Nomenclature (covering not only aero transported allergens)
-    is available at [http://www.allergen.org](http://www.allergen.org).
+    [polleninfo.org](https://www.polleninfo.org/en/allergy/profiles/alder.html)
+    a web site maintained by the European Aeroallergen Network. A World Health
+    Organization (WHO) Allergen Nomenclature (covering not only aero transported
+    allergens) is available at
+    [http://www.allergen.org](http://www.allergen.org).
 
 -   Attribute type: [Number](https://schema.org/Number)
 

--- a/specs/Environment/AeroAllergenObserved/doc/spec.md
+++ b/specs/Environment/AeroAllergenObserved/doc/spec.md
@@ -97,7 +97,7 @@ The structure of such an attribute will be as follows:
 -   Attribute name: Equal to the name of the allergen, for instance `alnus`. A
     list of commonly used aero allergens in Europe can be found on
     [polleninfo.org](https://www.polleninfo.org/en/allergy/profiles/alder.html)
-    a web site maintained by the European Aeroallergen Network. A World Health
+    a site maintained by the European Aeroallergen Network. A World Health
     Organization (WHO) Allergen Nomenclature (covering not only aero transported
     allergens) is available at
     [http://www.allergen.org](http://www.allergen.org).

--- a/specs/Environment/AirQualityObserved/README.md
+++ b/specs/Environment/AirQualityObserved/README.md
@@ -5,8 +5,8 @@ data as NGSI version 2.
 
 The data provided corresponds to different cities in Spain being the original
 data source different
-[air quality stations](../../PointOfInterest/AirQualityStation/README.md) managed by
-municipalities or regional governments.
+[air quality stations](../../PointOfInterest/AirQualityStation/README.md)
+managed by municipalities or regional governments.
 
 Please check the original data source before making use of this data in an
 application.

--- a/specs/Environment/unsupported/AirQualityThreshold/README.md
+++ b/specs/Environment/unsupported/AirQualityThreshold/README.md
@@ -1,7 +1,7 @@
 # Air quality threshold
 
-This folder contains a NGSI v2 data set which provides the air quality thresholds
-in Europe.
+This folder contains a NGSI v2 data set which provides the air quality
+thresholds in Europe.
 
 Air quality thresholds allow to calculate an air quality index (AQI).
 

--- a/specs/PointOfInterest/README.md
+++ b/specs/PointOfInterest/README.md
@@ -29,7 +29,7 @@ categories please check
 
 ## Examples of use
 
-```
+```text
 http://iotbd-v2.lab.fiware.org/v2/entities?type=PointOfInterest&q=category=='311'&limit=1
 ```
 

--- a/specs/Transportation/Bike/BikeHireDockingStation/doc/spec.md
+++ b/specs/Transportation/Bike/BikeHireDockingStation/doc/spec.md
@@ -209,24 +209,26 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 Bike hire docking station real time data in Malaga
 
-    {
-       "id": "malaga-bici-7"
-       "type": "BikeHireDockingStation",
-       "name": "07-Diputacion",
-       "location": {
-    	 "coordinates": [-4.43573, 36.699694],
-    	  "type": "Point"
-       },
-       "availableBikeNumber": 18,
-       "freeSlotNumber": 10,
-       "address": {
-    	  "streetAddress": "Paseo Antonio Banderas (Diputación)",
-    	  "addressLocality": "Malaga",
-    	  "addressCountry": "España"
-       },
-       "description": "Punto de alquiler de bicicletas próximo a Diputación",
-       "dateModified": "2017-05-09T09:25:55.00Z"
-    }
+```json
+{
+   "id": "malaga-bici-7"
+   "type": "BikeHireDockingStation",
+   "name": "07-Diputacion",
+   "location": {
+	 "coordinates": [-4.43573, 36.699694],
+	  "type": "Point"
+   },
+   "availableBikeNumber": 18,
+   "freeSlotNumber": 10,
+   "address": {
+	  "streetAddress": "Paseo Antonio Banderas (Diputación)",
+	  "addressLocality": "Malaga",
+	  "addressCountry": "España"
+   },
+   "description": "Punto de alquiler de bicicletas próximo a Diputación",
+   "dateModified": "2017-05-09T09:25:55.00Z"
+}
+```
 
 ## Use it with a real service
 

--- a/specs/Transportation/Road/doc/spec.md
+++ b/specs/Transportation/Road/doc/spec.md
@@ -65,8 +65,8 @@ The data model is defined as shown below:
 -   `roadClass` : The classification of this road.
 
     -   Attribute type: [Text](https://schema.org/Text)
-    -   Allowed values: Those described by [OpenStreetMap]
-        (http://wiki.openstreetmap.org/wiki/Key:highway).
+    -   Allowed values: Those described by
+        [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Key:highway).
     -   Mandatory
 
 -   `refRoadSegment` : Road segments which define this road.

--- a/specs/Transportation/Vehicle/VehicleModel/doc/spec.md
+++ b/specs/Transportation/Vehicle/VehicleModel/doc/spec.md
@@ -190,17 +190,19 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-    {
-      "id": "vehiclemodel:econic",
-      "type": "VehicleModel",
-      "name": "MBenz-Econic2014",
-      "brandName": "Mercedes Benz",
-      "modelName": "Econic",
-      "manufacturerName": "Daimler",
-      "vehicleType": "lorry",
-      "cargoVolume": 1000,
-      "fuelType": "diesel"
-    }
+```json
+{
+  "id": "vehiclemodel:econic",
+  "type": "VehicleModel",
+  "name": "MBenz-Econic2014",
+  "brandName": "Mercedes Benz",
+  "modelName": "Econic",
+  "manufacturerName": "Daimler",
+  "vehicleType": "lorry",
+  "cargoVolume": 1000,
+  "fuelType": "diesel"
+}
+```
 
 ## Test it with a real service
 

--- a/specs/UrbanMobility/GtfsAccessPoint/doc/spec.md
+++ b/specs/UrbanMobility/GtfsAccessPoint/doc/spec.md
@@ -120,8 +120,8 @@ Same as `GtfsStop`.
 
 ### Relationships
 
-| GTFS Field | NGSI Attribute     | LinkedGTFS | Comment                                                   |
-| :--------- | :----------------- | :--------- | :-------------------------------------------------------- |
+| GTFS Field | NGSI Attribute     | LinkedGTFS | Comment                                                  |
+| :--------- | :----------------- | :--------- | :------------------------------------------------------- |
 |            | `hasParentStation` |            | shall point to another Entity(ies) of type `GtfsStation` |
 
 ## Open issues

--- a/specs/UrbanMobility/GtfsCalendarDateRule/doc/spec.md
+++ b/specs/UrbanMobility/GtfsCalendarDateRule/doc/spec.md
@@ -119,8 +119,8 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Relationships
 
-| GTFS Field | NGSI Attribute | LinkedGTFS     | Comment                                              |
-| :--------- | :------------- | :------------- | :--------------------------------------------------- |
+| GTFS Field | NGSI Attribute | LinkedGTFS     | Comment                                             |
+| :--------- | :------------- | :------------- | :-------------------------------------------------- |
 |            | `hasService`   | `gtfs:service` | Shall point to another Entity of Type `GtfsService` |
 
 ## Open issues

--- a/specs/UrbanMobility/GtfsCalendarRule/doc/spec.md
+++ b/specs/UrbanMobility/GtfsCalendarRule/doc/spec.md
@@ -199,8 +199,8 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Relationships
 
-| GTFS Field | NGSI Attribute | LinkedGTFS     | Comment                                              |
-| :--------- | :------------- | :------------- | :--------------------------------------------------- |
+| GTFS Field | NGSI Attribute | LinkedGTFS     | Comment                                             |
+| :--------- | :------------- | :------------- | :-------------------------------------------------- |
 |            | `hasService`   | `gtfs:service` | Shall point to another Entity of Type `GtfsService` |
 
 ## Open issues

--- a/specs/UrbanMobility/GtfsFrequency/doc/spec.md
+++ b/specs/UrbanMobility/GtfsFrequency/doc/spec.md
@@ -141,8 +141,8 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Relationships
 
-| GTFS Field | NGSI Attribute | LinkedGTFS | Comment                                         |
-| :--------- | :------------- | :--------- | :---------------------------------------------- |
+| GTFS Field | NGSI Attribute | LinkedGTFS | Comment                                        |
+| :--------- | :------------- | :--------- | :--------------------------------------------- |
 | `trip_id`  | `hasTrip`      |            | It shall point to an Entity of Type `GtfsTrip` |
 
 ### Open issues

--- a/specs/UrbanMobility/GtfsRoute/doc/spec.md
+++ b/specs/UrbanMobility/GtfsRoute/doc/spec.md
@@ -150,8 +150,8 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Relationships
 
-| GTFS Field | NGSI Attribute | LinkedGTFS    | Comment                                             |
-| :--------- | :------------- | :------------ | :-------------------------------------------------- |
+| GTFS Field | NGSI Attribute | LinkedGTFS    | Comment                                            |
+| :--------- | :------------- | :------------ | :------------------------------------------------- |
 |            | `operatedBy`   | `gtfs:agency` | Shall point to another Entity of Type `GtfsAgency` |
 
 ### Open issues

--- a/specs/UrbanMobility/GtfsService/doc/spec.md
+++ b/specs/UrbanMobility/GtfsService/doc/spec.md
@@ -105,8 +105,8 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Relationships
 
-| GTFS Field | NGSI Attribute | LinkedGTFS    | Comment                                             |
-| :--------- | :------------- | :------------ | :-------------------------------------------------- |
+| GTFS Field | NGSI Attribute | LinkedGTFS    | Comment                                            |
+| :--------- | :------------- | :------------ | :------------------------------------------------- |
 |            | `operatedBy`   | `gtfs:agency` | Shall point to another Entity of Type `GtfsAgency` |
 
 ## Open issues

--- a/specs/UrbanMobility/GtfsShape/doc/spec.md
+++ b/specs/UrbanMobility/GtfsShape/doc/spec.md
@@ -21,12 +21,13 @@ The data model is defined as shown below:
 
     -   It shall be equal to `GtfsShape`
 
-- `source` : A sequence of characters giving the source of the entity data.
+-   `source` : A sequence of characters giving the source of the entity data.
 
     -   Attribute type: Text or URL
     -   Optional
 
-- `dataProvider` : Specifies the URL to information about the provider of this information
+-   `dataProvider` : Specifies the URL to information about the provider of this
+    information
 
     -   Attribute type: URL
     -   Optional
@@ -41,18 +42,21 @@ The data model is defined as shown below:
     -   Attribute type: [DateTime](https://schema.org/DateTime)
     -   Read-Only. Automatically generated.
 
--   `location`: The geographical shape associated to this entity encoded as GeoJSON
-    `LineString` or `MultiLineString`. The coordinates shall be obtained from
-    the `shapes.txt` feed file as per the value of `shape_id`, `shape_pt_lat`, `shape_pt_lon`, `shape_pt_sequence`.
-    
+-   `location`: The geographical shape associated to this entity encoded as
+    GeoJSON `LineString` or `MultiLineString`. The coordinates shall be obtained
+    from the `shapes.txt` feed file as per the value of `shape_id`,
+    `shape_pt_lat`, `shape_pt_lon`, `shape_pt_sequence`.
+
     -   Attribute type: GeoProperty. `geo:json`
     -   Optional
 
--   `distanceTravelled`: An array of the distance travelled when reaching each of the points that make the `LineString` or `MultiLineString` that represents this shape. It shall match the
-same number of elements as the corresponding `LineString` or `MultiLineString`. 
+-   `distanceTravelled`: An array of the distance travelled when reaching each
+    of the points that make the `LineString` or `MultiLineString` that
+    represents this shape. It shall match the same number of elements as the
+    corresponding `LineString` or `MultiLineString`.
 
-    - Attribute type: List of Number if the Shape is defined by a `LineString`. List of List of Number if the Shape is defined by a `MultiLineString`.
-    - Optional
+        - Attribute type: List of Number if the Shape is defined by a `LineString`. List of List of Number if the Shape is defined by a `MultiLineString`.
+        - Optional
 
 ### Example 1 (Normalized Format)
 
@@ -112,17 +116,17 @@ same number of elements as the corresponding `LineString` or `MultiLineString`.
 
 ### Properties
 
-| GTFS Field            | NGSI Attribute         | LinkedGTFS                  | Comment                                                  |
-| :-------------------- | :--------------------- | :-------------------------- | :------------------------------------------------------- |
-| `shape_pt_lat`        | `location`             | `geo:lat`                   | Latitude of points.                                      |
-| `shape_pt_lon`        | `location`             | `geo:long`                  | Longitude of points.                                     |
-| `shape_pt_sequence`   | `location`             | `gtfs:pointSequence`        | Sequence of points.                                      |
-| `shape_dist_traveled` | `distanceTravelled`    | `gtfs:distanceTravelled`    | Distance travelled                                       |
+| GTFS Field            | NGSI Attribute      | LinkedGTFS               | Comment              |
+| :-------------------- | :------------------ | :----------------------- | :------------------- |
+| `shape_pt_lat`        | `location`          | `geo:lat`                | Latitude of points.  |
+| `shape_pt_lon`        | `location`          | `geo:long`               | Longitude of points. |
+| `shape_pt_sequence`   | `location`          | `gtfs:pointSequence`     | Sequence of points.  |
+| `shape_dist_traveled` | `distanceTravelled` | `gtfs:distanceTravelled` | Distance travelled   |
 
 ### Relationships
 
-| GTFS Field       | NGSI Attribute     | LinkedGTFS           | Comment                                              |
-| :--------------- | :----------------- | :------------------- | :--------------------------------------------------- |
+| GTFS Field | NGSI Attribute | LinkedGTFS | Comment |
+| :--------- | :------------- | :--------- | :------ |
 
 
 ## Open issues

--- a/specs/UrbanMobility/GtfsStation/doc/spec.md
+++ b/specs/UrbanMobility/GtfsStation/doc/spec.md
@@ -134,8 +134,8 @@ Same as [GtfsStop](../../GtfsStop/doc/spec.md)
 
 ### Relationships
 
-| GTFS Field | NGSI Attribute     | LinkedGTFS | Comment                                            |
-| :--------- | :----------------- | :--------- | :------------------------------------------------- |
+| GTFS Field | NGSI Attribute     | LinkedGTFS | Comment                                           |
+| :--------- | :----------------- | :--------- | :------------------------------------------------ |
 |            | `hasStop`          |            | shall point to Entities of type `GtfsStop`        |
 |            | `hasAccessPoint`   |            | shall point to Entities of type `GtfsAccessPoint` |
 |            | `hasParentStation` |            | shall point to an Entity of type `GtfsStation`    |

--- a/specs/UrbanMobility/GtfsStop/doc/spec.md
+++ b/specs/UrbanMobility/GtfsStop/doc/spec.md
@@ -164,8 +164,8 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Relationships
 
-| GTFS Field       | NGSI Attribute     | LinkedGTFS           | Comment                                              |
-| :--------------- | :----------------- | :------------------- | :--------------------------------------------------- |
+| GTFS Field       | NGSI Attribute     | LinkedGTFS           | Comment                                             |
+| :--------------- | :----------------- | :------------------- | :-------------------------------------------------- |
 | `parent_station` | `hasParentStation` | `gtfs:parentStation` | Shall point to another Entity of Type `GtfsStation` |
 |                  | `operatedBy`       |                      | Shall point to another Entity of Type `GtfsAgency`  |
 

--- a/specs/UrbanMobility/GtfsTransferRule/doc/spec.md
+++ b/specs/UrbanMobility/GtfsTransferRule/doc/spec.md
@@ -132,8 +132,8 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Relationships
 
-| GTFS Field     | NGSI Attribute   | LinkedGTFS             | Comment                                                           |
-| :------------- | :--------------- | :--------------------- | :---------------------------------------------------------------- |
+| GTFS Field     | NGSI Attribute   | LinkedGTFS             | Comment                                                         |
+| :------------- | :--------------- | :--------------------- | :-------------------------------------------------------------- |
 | `from_stop_id` | `hasOrigin`      | `gtfs:originStop`      | It shall point to an Entity of Type `GtfsStop` or `GtfsStation` |
 | `to_stop_id`   | `hasDestination` | `gtfs:destinationStop` | It shall point to an Entity of Type `GtfsStop` or `GtfsStation` |
 

--- a/specs/UrbanMobility/GtfsTrip/doc/spec.md
+++ b/specs/UrbanMobility/GtfsTrip/doc/spec.md
@@ -65,12 +65,12 @@ The data model is defined as shown below:
     -   Attribute type: Relationship. It shall point to an Entity of Type
         [GtfsService](../../GtfsService/doc/spec.md)
     -   Optional
-    
+
 -   `hasShape`: Same as GTFS `shape_id`.
 
     -   Attribute type: Relationship. It shall point to an Entity of Type
         [GtfsShape](../../GtfsShape/doc/spec.md)
-    -   Optional    
+    -   Optional
 
 -   `hasRoute`: Same as `route_id`.
 
@@ -142,20 +142,20 @@ Sample uses simplified representation for data consumers `?options=keyValues`
 
 ### Properties
 
-| GTFS Field              | NGSI Attribute         | LinkedGTFS                  | Comment                                                 |
-| :---------------------- | :--------------------- | :-------------------------- | :------------------------------------------------------ |
-| `trip_headsign`         | `headSign`             | `gtfs:headsign`             |                                                         |
-| `trip_short_name`       | `shortName`            | `gtfs:shortName`            |                                                         |
-| `direction_id`          | `direction`            | `gtfs:direction`            |                                                         |
-| `block_id`              | `block`                | `gtfs:block`                |                                                         |
-| `wheelchair_accessible` | `wheelchairAccessible` | `gtfs:wheelchairAccessible` |                                                         |
-| `bikes_allowed`         | `bikesAllowed`         | `gtfs:bikesAllowed`         |                                                         |
+| GTFS Field              | NGSI Attribute         | LinkedGTFS                  | Comment |
+| :---------------------- | :--------------------- | :-------------------------- | :------ |
+| `trip_headsign`         | `headSign`             | `gtfs:headsign`             |         |
+| `trip_short_name`       | `shortName`            | `gtfs:shortName`            |         |
+| `direction_id`          | `direction`            | `gtfs:direction`            |         |
+| `block_id`              | `block`                | `gtfs:block`                |         |
+| `wheelchair_accessible` | `wheelchairAccessible` | `gtfs:wheelchairAccessible` |         |
+| `bikes_allowed`         | `bikesAllowed`         | `gtfs:bikesAllowed`         |         |
 
 ### Relationships
 
-| GTFS Field   | NGSI Attribute | LinkedGTFS     | Comment                                            |
-| :----------- | :------------- | :------------- | :------------------------------------------------- |
-| `route_id`   | `hasRoute`     |                |                                                    |
+| GTFS Field   | NGSI Attribute | LinkedGTFS     | Comment                                           |
+| :----------- | :------------- | :------------- | :------------------------------------------------ |
+| `route_id`   | `hasRoute`     |                |                                                   |
 | `service_id` | `hasService`   | `gtfs:service` | It shall point to an Entity of Type `GtfsService` |
 | `shape_id`   | `hasShape`     | `gtfs:shape`   | It shall point to an Entity of Type `GtfsShape`   |
 

--- a/specs/UrbanMobility/README.md
+++ b/specs/UrbanMobility/README.md
@@ -2,23 +2,24 @@
 
 ## Introduction
 
- The General Transit Feed Specification (GTFS), also known as GTFS static or static transit,
- defines a common format for public transportation schedules and associated geographic information.
- GTFS "feeds" let public transit agencies publish their transit data and developers write applications that consume
- that data in an interoperable way.
- 
- These data models are intended to map GTFS feeds into FIWARE NGSI content. Main entities are:
- 
-+ [GtfsAgency](./GtfsAgency/doc/spec.md)
-+ [GtfsStop](./GtfsStop/doc/spec.md)
-+ [GtfsStation](./GtfsStation/doc/spec.md)
-+ [GtfsAccessPoint](./GtfsAccessPoint/doc/spec.md)
-+ [GtfsRoute](./GtfsRoute/doc/spec.md)
-+ [GtfsTrip](./GtfsTrip/doc/spec.md)
-+ [GtfsStopTime](./GtfsStopTime/doc/spec.md)
-+ [GtfsService](./GtfsService/doc/spec.md)
-+ [GtfsCalendarRule](./GtfsCalendarRule/doc/spec.md)
-+ [GtfsCalendarDateRule](./GtfsCalendarDateRule/doc/spec.md)
-+ [GtfsFrequency](./GtfsFrequency/doc/spec.md)
-+ [GtfsTransferRule](./GtfsTransferRule/doc/spec.md)
- 
+The General Transit Feed Specification (GTFS), also known as GTFS static or
+static transit, defines a common format for public transportation schedules and
+associated geographic information. GTFS "feeds" let public transit agencies
+publish their transit data and developers write applications that consume that
+data in an interoperable way.
+
+These data models are intended to map GTFS feeds into FIWARE NGSI content. Main
+entities are:
+
+-   [GtfsAgency](./GtfsAgency/doc/spec.md)
+-   [GtfsStop](./GtfsStop/doc/spec.md)
+-   [GtfsStation](./GtfsStation/doc/spec.md)
+-   [GtfsAccessPoint](./GtfsAccessPoint/doc/spec.md)
+-   [GtfsRoute](./GtfsRoute/doc/spec.md)
+-   [GtfsTrip](./GtfsTrip/doc/spec.md)
+-   [GtfsStopTime](./GtfsStopTime/doc/spec.md)
+-   [GtfsService](./GtfsService/doc/spec.md)
+-   [GtfsCalendarRule](./GtfsCalendarRule/doc/spec.md)
+-   [GtfsCalendarDateRule](./GtfsCalendarDateRule/doc/spec.md)
+-   [GtfsFrequency](./GtfsFrequency/doc/spec.md)
+-   [GtfsTransferRule](./GtfsTransferRule/doc/spec.md)

--- a/specs/UrbanMobility/doc/introduction.md
+++ b/specs/UrbanMobility/doc/introduction.md
@@ -2,38 +2,41 @@
 
 ## Introduction
 
- The General Transit Feed Specification (GTFS), also known as GTFS static or static transit,
- defines a common format for public transportation schedules and associated geographic information.
- GTFS "feeds" let public transit agencies publish their transit data and developers write applications that consume
- that data in an interoperable way.
- 
- This document provides guidelines on how to map GTFS feeds into FIWARE NGSI content.
- This work leverages on [LinkedGTFS specification](https://github.com/OpenTransport/linked-gtfs/blob/master/spec.md).
- Whenever possible the NGSI attributes map directly to GTFS fields. Nonethless for some Entity Types extra attributes are suggested in order
- to better support the data model using the NGSI information model. 
- 
+The General Transit Feed Specification (GTFS), also known as GTFS static or
+static transit, defines a common format for public transportation schedules and
+associated geographic information. GTFS "feeds" let public transit agencies
+publish their transit data and developers write applications that consume that
+data in an interoperable way.
+
+This document provides guidelines on how to map GTFS feeds into FIWARE NGSI
+content. This work leverages on
+[LinkedGTFS specification](https://github.com/OpenTransport/linked-gtfs/blob/master/spec.md).
+Whenever possible the NGSI attributes map directly to GTFS fields. Nonethless
+for some Entity Types extra attributes are suggested in order to better support
+the data model using the NGSI information model.
+
 ## General rules
- 
- Entity Attributes (Properties or Relationships) are subject to the restrictions defined by the
- [GTFS specification](https://developers.google.com/transit/gtfs/reference/#term-definitions)
- If an Attribute is an enumeration its value shall be provided as per the GTFS specification (not LinkedGTFS). 
+
+Entity Attributes (Properties or Relationships) are subject to the restrictions
+defined by the
+[GTFS specification](https://developers.google.com/transit/gtfs/reference/#term-definitions)
+If an Attribute is an enumeration its value shall be provided as per the GTFS
+specification (not LinkedGTFS).
 
 ## Summary of Entity mappings with GTFS
 
-
-| GTFS Feed Member Name                                                                           | NGSI Entity Type                                                                                                                    |
-|:----------------------------------------------------------------------------------------------- |:------------------------------------------------------------------------------------------------------------------------------------|
-| [agency.txt](https://developers.google.com/transit/gtfs/reference/#agencytxt)                   |   [GtfsAgency](../GtfsAgency/doc/spec.md)                                                                                           |
-| [stops.txt](https://developers.google.com/transit/gtfs/reference/#stopstxt)                     |   [GtfsStop](../GtfsStop/doc/spec.md). [GtfsStation](../GtfsStation/doc/spec.md). [GtfsAccessPoint](../GtfsAccessPoint/doc/spec.md) |
-| [routes.txt](https://developers.google.com/transit/gtfs/reference/#routestxt)                   |   [GtfsRoute](../GtfsRoute/doc/spec.md)                                                                                             |
-| [trips.txt](https://developers.google.com/transit/gtfs/reference/#tripstxt)                     |   [GtfsTrip](../GtfsTrip/doc/spec.md). See also [GtfsService](../GtfsService/doc/spec.md)                                           |
-| [stop_times.txt](https://developers.google.com/transit/gtfs/reference/#stop_timestxt)           |   [GtfsStopTime](../GtfsStopTime/doc/spec.md)                                                                                       |
-| [calendar.txt](https://developers.google.com/transit/gtfs/reference/#calendartxt)               |   [GtfsCalendarRule](../GtfsCalendarRule/doc/spec.md)                                                                               |
-| [calendar_dates.txt](https://developers.google.com/transit/gtfs/reference/#calendar_datestxt)   |   [GtfsCalendarDateRule](../GtfsCalendarDateRule/doc/spec.md)                                                                       |  
-| [fare_attributes.txt](https://developers.google.com/transit/gtfs/reference/#fare_attributestxt) |   N/A                                                                                                                               |
-| [fare_rules.txt](https://developers.google.com/transit/gtfs/reference/#fare_rulestxt)           |   N/A                                                                                                                               |
-| [shapes.txt](https://developers.google.com/transit/gtfs/reference/#shapestxt)                   |   See   [GtfsRoute](../GtfsRoute/doc/spec.md),   [GtfsTrip](../GtfsTrip/doc/spec.md)                                                |
-| [frequencies.txt](https://developers.google.com/transit/gtfs/reference/#frequenciestxt)         |   [GtfsFrequency](../GtfsFrequency/doc/spec.md)                                                                                     |
-| [transfers.txt](https://developers.google.com/transit/gtfs/reference/#transferstxt)             |   [GtfsTransferRule](../GtfsTransferRule/doc/spec.md)                                                                               |
-| [feedinfo.txt](https://developers.google.com/transit/gtfs/reference/#feed_infotxt)              |   N/A                                                                                                                               |
-
+| GTFS Feed Member Name                                                                           | NGSI Entity Type                                                                                                                  |
+| :---------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| [agency.txt](https://developers.google.com/transit/gtfs/reference/#agencytxt)                   | [GtfsAgency](../GtfsAgency/doc/spec.md)                                                                                           |
+| [stops.txt](https://developers.google.com/transit/gtfs/reference/#stopstxt)                     | [GtfsStop](../GtfsStop/doc/spec.md). [GtfsStation](../GtfsStation/doc/spec.md). [GtfsAccessPoint](../GtfsAccessPoint/doc/spec.md) |
+| [routes.txt](https://developers.google.com/transit/gtfs/reference/#routestxt)                   | [GtfsRoute](../GtfsRoute/doc/spec.md)                                                                                             |
+| [trips.txt](https://developers.google.com/transit/gtfs/reference/#tripstxt)                     | [GtfsTrip](../GtfsTrip/doc/spec.md). See also [GtfsService](../GtfsService/doc/spec.md)                                           |
+| [stop_times.txt](https://developers.google.com/transit/gtfs/reference/#stop_timestxt)           | [GtfsStopTime](../GtfsStopTime/doc/spec.md)                                                                                       |
+| [calendar.txt](https://developers.google.com/transit/gtfs/reference/#calendartxt)               | [GtfsCalendarRule](../GtfsCalendarRule/doc/spec.md)                                                                               |
+| [calendar_dates.txt](https://developers.google.com/transit/gtfs/reference/#calendar_datestxt)   | [GtfsCalendarDateRule](../GtfsCalendarDateRule/doc/spec.md)                                                                       |
+| [fare_attributes.txt](https://developers.google.com/transit/gtfs/reference/#fare_attributestxt) | N/A                                                                                                                               |
+| [fare_rules.txt](https://developers.google.com/transit/gtfs/reference/#fare_rulestxt)           | N/A                                                                                                                               |
+| [shapes.txt](https://developers.google.com/transit/gtfs/reference/#shapestxt)                   | See [GtfsRoute](../GtfsRoute/doc/spec.md), [GtfsTrip](../GtfsTrip/doc/spec.md)                                                    |
+| [frequencies.txt](https://developers.google.com/transit/gtfs/reference/#frequenciestxt)         | [GtfsFrequency](../GtfsFrequency/doc/spec.md)                                                                                     |
+| [transfers.txt](https://developers.google.com/transit/gtfs/reference/#transferstxt)             | [GtfsTransferRule](../GtfsTransferRule/doc/spec.md)                                                                               |
+| [feedinfo.txt](https://developers.google.com/transit/gtfs/reference/#feed_infotxt)              | N/A                                                                                                                               |

--- a/specs/UrbanMobility/unsupported/ArrivalEstimation/doc/spec.md
+++ b/specs/UrbanMobility/unsupported/ArrivalEstimation/doc/spec.md
@@ -2,117 +2,138 @@
 
 ## Description
 
-This entity Type is intended to provide arrival estimation information that can be used either in a standalone manner or to generate GTFS-RT feeds that complement a GTFS static file.
+This entity Type is intended to provide arrival estimation information that can
+be used either in a standalone manner or to generate GTFS-RT feeds that
+complement a GTFS static file.
 
 ## Data Model
-+ `id`: Entity ID
-    + It shall be `urn:ngsi-ld:ArrivalEstimation:<identifier>`
 
-+ `type`: Entity Type
-    + It shall be equal to `ArrivalEstimation`
+-   `id`: Entity ID
 
-+ `refGtfsTransitFeedFile` : Reference to the entity pointing to the external GTFS file.
-    + Attribute type: [URL](https://schema.org/URL)
-    + Optional. Necessary to create GTFS-RT feeds
+    -   It shall be `urn:ngsi-ld:ArrivalEstimation:<identifier>`
 
-+ `routeId` : Identifier of the bus route (or bus line)
-    + Attribute type: [Text](https://schema.org/Text)
-    + Mandatory
+-   `type`: Entity Type
 
-+ `stopId` : Identifier of the stop
-    + Attribute type: [Text](https://schema.org/Text)
-    + Mandatory if `stopSequence` is not defined
+    -   It shall be equal to `ArrivalEstimation`
 
-+ `dateCreated` : Entity's creation timestamp.
-    + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated.
+-   `refGtfsTransitFeedFile` : Reference to the entity pointing to the external
+    GTFS file.
 
-+ `dateModified` : Last update timestamp of this Entity.
-    + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Read-Only. Automatically generated.
+    -   Attribute type: [URL](https://schema.org/URL)
+    -   Optional. Necessary to create GTFS-RT feeds
 
-+ `lastUpdatedAt` : Last update of the entity set by the data provider. It is not automatically generated.
-    + Attribute type: [DateTime](https://schema.org/DateTime)
-    + Optional.
+-   `routeId` : Identifier of the bus route (or bus line)
 
-+ `arrivalEstimationUpdate` : Current updates of the trips referred to the route/stop pair
-    + Attribute type: Array of [StructuredValue](https://schema.org/StructuredValue)
-    + Subproperties (items):
-    	+ `arrivalDelay`: Delay in seconds (positive or negative). 0 means that the vehicle is on time
-    		+ Type: [Integer](https://schema.org/Integer)
-    		+ Optional. Necessary to create GTFS-RT feeds
-    	+ `arrivalTime`: Estimated arrival time in absolute time value (timestamp ISO 8601)
-    		+ Type: [DateTime](https://schema.org/DateTime)
-    		+ Optional. Mandatory if arrivalDelay is not defined
-    	+ `tripId`: Identifier of the trip as defined in the associated GTFS
-    		+ Type: [Text](https://schema.org/Text)
-    		+ Optional. Mandatory if neither `vehicleId` or `vehicleLabel` are defined. Necessary to create GTFS-RT feeds
-    	+ `vehicleId`: Vehicle identifier corresponding to the estimate
-    		+ Type: [Text](https://schema.org/Text)
-    		+ Optional. Mandatory if neither `tripId` or `vehicleLabel` are defined
-    	+ `vehicleLabel`: Human readable label to identify the vehicle
-    		+ Type: [Text](https://schema.org/Text)
-    		+ Optional. Mandatory if neither `tripId` or `vehicleId` are defined
-	+ Mandatory
+    -   Attribute type: [Text](https://schema.org/Text)
+    -   Mandatory
+
+-   `stopId` : Identifier of the stop
+
+    -   Attribute type: [Text](https://schema.org/Text)
+    -   Mandatory if `stopSequence` is not defined
+
+-   `dateCreated` : Entity's creation timestamp.
+
+    -   Attribute type: [DateTime](https://schema.org/DateTime)
+    -   Read-Only. Automatically generated.
+
+-   `dateModified` : Last update timestamp of this Entity.
+
+    -   Attribute type: [DateTime](https://schema.org/DateTime)
+    -   Read-Only. Automatically generated.
+
+-   `lastUpdatedAt` : Last update of the entity set by the data provider. It is
+    not automatically generated.
+
+    -   Attribute type: [DateTime](https://schema.org/DateTime)
+    -   Optional.
+
+-   `arrivalEstimationUpdate` : Current updates of the trips referred to the
+    route/stop pair
+    -   Attribute type: Array of
+        [StructuredValue](https://schema.org/StructuredValue)
+    -   Subproperties (items):
+        -   `arrivalDelay`: Delay in seconds (positive or negative). 0 means
+            that the vehicle is on time + Type:
+            [Integer](https://schema.org/Integer) + Optional. Necessary to
+            create GTFS-RT feeds
+        -   `arrivalTime`: Estimated arrival time in absolute time value
+            (timestamp ISO 8601) + Type:
+            [DateTime](https://schema.org/DateTime) + Optional. Mandatory if
+            arrivalDelay is not defined
+        -   `tripId`: Identifier of the trip as defined in the associated GTFS +
+            Type: [Text](https://schema.org/Text) + Optional. Mandatory if
+            neither `vehicleId` or `vehicleLabel` are defined. Necessary to
+            create GTFS-RT feeds
+        -   `vehicleId`: Vehicle identifier corresponding to the estimate +
+            Type: [Text](https://schema.org/Text) + Optional. Mandatory if
+            neither `tripId` or `vehicleLabel` are defined
+        -   `vehicleLabel`: Human readable label to identify the vehicle + Type:
+            [Text](https://schema.org/Text) + Optional. Mandatory if neither
+            `tripId` or `vehicleId` are defined + Mandatory
 
 ### Examples of use 1 (Normalized Format)
 
 ```json
 {
-  "id": "urn:ngsi-ld:ArrivalEstimation:Santander:1",
-  "type": "ArrivalEstimation",
-  "refGtfsTransitFeedFile": {
-    "value": "urn:ngsi-ld:GtfsTransitFeedFile:Santander:bus"
-  },
-  "routeId": {
-    "value": "route1"
-  },
-  "stopId": {
-    "value": "stop1"
-  },
-  "lastUpdatedAt": {
-    "value": "2018-12-19T10:14:00.238Z",
-    "type": "DateTime"
-  },
-  "arrivalEstimationUpdate": {
-    "value": [
-      {
-        "tripId": "1",
-        "arrivalDelay": -2
-      }, {
-        "tripId": "2",
-        "arrivalDelay": -2
-      }, {
-        "tripId": "3",
-        "arrivalDelay": -2
-      }
-    ]
-  }
+    "id": "urn:ngsi-ld:ArrivalEstimation:Santander:1",
+    "type": "ArrivalEstimation",
+    "refGtfsTransitFeedFile": {
+        "value": "urn:ngsi-ld:GtfsTransitFeedFile:Santander:bus"
+    },
+    "routeId": {
+        "value": "route1"
+    },
+    "stopId": {
+        "value": "stop1"
+    },
+    "lastUpdatedAt": {
+        "value": "2018-12-19T10:14:00.238Z",
+        "type": "DateTime"
+    },
+    "arrivalEstimationUpdate": {
+        "value": [
+            {
+                "tripId": "1",
+                "arrivalDelay": -2
+            },
+            {
+                "tripId": "2",
+                "arrivalDelay": -2
+            },
+            {
+                "tripId": "3",
+                "arrivalDelay": -2
+            }
+        ]
+    }
 }
 ```
 
-### Examples of use 2  (?options=keyValues simplified representation for data consumers)
+### Examples of use 2 (?options=keyValues simplified representation for data consumers)
 
 ```json
 {
-  "id": "urn:ngsi-ld:ArrivalEstimation:Santander:1",
-  "type": "ArrivalEstimation",
-  "refGtfsTransitFeedFile": "urn:ngsi-ld:GtfsTransitFeedFile:Santander:bus",
-  "routeId": "route1",
-  "stopId": "stop1",
-  "lastUpdatedAt": "2018-12-19T10:14:00.238Z",
-  "arrivalEstimationUpdate": [
-    {
-      "tripId": "1",
-      "arrivalDelay": -2
-    }, {
-      "tripId": "2",
-      "arrivalDelay": -2
-    }, {
-      "tripId": "3",
-      "arrivalDelay": -2
-    }
-  ]
+    "id": "urn:ngsi-ld:ArrivalEstimation:Santander:1",
+    "type": "ArrivalEstimation",
+    "refGtfsTransitFeedFile": "urn:ngsi-ld:GtfsTransitFeedFile:Santander:bus",
+    "routeId": "route1",
+    "stopId": "stop1",
+    "lastUpdatedAt": "2018-12-19T10:14:00.238Z",
+    "arrivalEstimationUpdate": [
+        {
+            "tripId": "1",
+            "arrivalDelay": -2
+        },
+        {
+            "tripId": "2",
+            "arrivalDelay": -2
+        },
+        {
+            "tripId": "3",
+            "arrivalDelay": -2
+        }
+    ]
 }
 ```
 

--- a/specs/User/Activity/README.md
+++ b/specs/User/Activity/README.md
@@ -20,15 +20,15 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```json
 {
-  "id": "UserActivity1",
-  "type": "UserActivity",
-  "activityType": "Drive",
-  "description": "User1 drive Car1 to Office1",
-  "dateActivityStarted": "2016-11-30T07:00:00.00Z",
-  "refObject": "Car1",
-  "refTarget": "Office1",
-  "refAgent": "User1"
+    "id": "UserActivity1",
+    "type": "UserActivity",
+    "activityType": "Drive",
+    "description": "User1 drive Car1 to Office1",
+    "dateActivityStarted": "2016-11-30T07:00:00.00Z",
+    "refObject": "Car1",
+    "refTarget": "Office1",
+    "refAgent": "User1"
 }
 ```

--- a/specs/Weather/WeatherAlert/README.md
+++ b/specs/Weather/WeatherAlert/README.md
@@ -15,7 +15,7 @@ API implementation, you need to use the `keyValues` mode (`options=keyValues`).
 
 ## Examples of use
 
-```
+```bash
 curl http://<orion_host:port>/v2/entities?type=Alert&q=category==weather&address.addressCountry==ES
 ```
 

--- a/specs/Weather/WeatherForecast/doc/spec.md
+++ b/specs/Weather/WeatherForecast/doc/spec.md
@@ -246,43 +246,40 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-```
+```json
 {
-        "id": "Spain-WeatherForecast-46005_2016-12-01T18:00:00_2016-12-02T00:00:00",
-        "type": "WeatherForecast",
-        "address":
-        {
-            "addressCountry": "Spain",
-            "postalCode": "46005",
-            "addressLocality": "Valencia"
-        },
-        "dataProvider": "TEF",
-        "dateIssued": "2016-12-01T10:40:01.00Z",
-        "dateRetrieved": "2016-12-01T12:57:24.00Z",
-        "dayMaximum":
-        {
-            "feelsLikeTemperature": 15,
-            "temperature": 15,
-            "relativeHumidity": 0.9
-        },
-        "dayMinimum":
-        {
-            "feelsLikeTemperature": 11,
-            "temperature": 11,
-            "relativeHumidity": 0.7
-        },
-        "feelsLikeTemperature": 12,
-        "precipitationProbability": 0.15,
-        "relativeHumidity": 0.85,
-        "source": "http://www.aemet.es/xml/municipios/localidad_46250.xml",
-        "temperature": 12,
-        "validFrom": "2016-12-01T17:00:00.00Z",
-        "validTo": "2016-12-01T23:00:00.00Z",
-        "validity": "2016-12-01T18:00:00+01:00/2016-12-02T00:00:00+01:00",
-        "weatherType": "overcast",
-        "windDirection": null,
-        "windSpeed": 0
-    }
+    "id": "Spain-WeatherForecast-46005_2016-12-01T18:00:00_2016-12-02T00:00:00",
+    "type": "WeatherForecast",
+    "address": {
+        "addressCountry": "Spain",
+        "postalCode": "46005",
+        "addressLocality": "Valencia"
+    },
+    "dataProvider": "TEF",
+    "dateIssued": "2016-12-01T10:40:01.00Z",
+    "dateRetrieved": "2016-12-01T12:57:24.00Z",
+    "dayMaximum": {
+        "feelsLikeTemperature": 15,
+        "temperature": 15,
+        "relativeHumidity": 0.9
+    },
+    "dayMinimum": {
+        "feelsLikeTemperature": 11,
+        "temperature": 11,
+        "relativeHumidity": 0.7
+    },
+    "feelsLikeTemperature": 12,
+    "precipitationProbability": 0.15,
+    "relativeHumidity": 0.85,
+    "source": "http://www.aemet.es/xml/municipios/localidad_46250.xml",
+    "temperature": 12,
+    "validFrom": "2016-12-01T17:00:00.00Z",
+    "validTo": "2016-12-01T23:00:00.00Z",
+    "validity": "2016-12-01T18:00:00+01:00/2016-12-02T00:00:00+01:00",
+    "weatherType": "overcast",
+    "windDirection": null,
+    "windSpeed": 0
+}
 ```
 
 ## Use it with a real service

--- a/specs/Weather/WeatherObserved/doc/spec.md
+++ b/specs/Weather/WeatherObserved/doc/spec.md
@@ -314,37 +314,31 @@ Normalized NGSI response
 
 Sample uses simplified representation for data consumers `?options=keyValues`
 
-```
+```json
 {
-            "id": "Spain-WeatherObserved-2422-2016-11-30T08:00:00",
-            "type": "WeatherObserved",
-            "address":
-            {
-                "addressLocality": "Valladolid",
-                "addressCountry": "ES"
-            },
-            "atmosphericPressure": 938.9,
-            "dataProvider": "TEF",
-            "dateObserved": "2016-11-30T07:00:00.00Z",
-            "location":
-            {
-                "type": "Point",
-                "coordinates":
-                [
-                    -4.754444444,
-                    41.640833333
-                ]
-            },
-            "precipitation": 0,
-            "pressureTendency": 0.5,
-            "relativeHumidity": 1,
-            "source": "http://www.aemet.es",
-            "stationCode": "2422",
-            "stationName": "Valladolid",
-            "temperature": 3.3,
-            "windDirection": -45,
-            "windSpeed": 2,
-            "illuminance": 1000
+    "id": "Spain-WeatherObserved-2422-2016-11-30T08:00:00",
+    "type": "WeatherObserved",
+    "address": {
+        "addressLocality": "Valladolid",
+        "addressCountry": "ES"
+    },
+    "atmosphericPressure": 938.9,
+    "dataProvider": "TEF",
+    "dateObserved": "2016-11-30T07:00:00.00Z",
+    "location": {
+        "type": "Point",
+        "coordinates": [-4.754444444, 41.640833333]
+    },
+    "precipitation": 0,
+    "pressureTendency": 0.5,
+    "relativeHumidity": 1,
+    "source": "http://www.aemet.es",
+    "stationCode": "2422",
+    "stationName": "Valladolid",
+    "temperature": 3.3,
+    "windDirection": -45,
+    "windSpeed": 2,
+    "illuminance": 1000
 }
 ```
 

--- a/validator/.textlintrc
+++ b/validator/.textlintrc
@@ -193,7 +193,8 @@
           "http://schema.org/*",
           "https://www.tourspain.es/en-us",
           "http://apidirectory.connectedliving.gsma.com",
-          "http://apidirectory.connectedliving.gsma.com/*"
+          "http://apidirectory.connectedliving.gsma.com/api/air-quality-spain",
+          "http://apidirectory.connectedliving.gsma.com/api/weather-spain"
       ]
     }
   }

--- a/validator/.textlintrc
+++ b/validator/.textlintrc
@@ -191,7 +191,9 @@
           "mailto:*",
           "https://schema.org/*",
           "http://schema.org/*",
-          "https://www.tourspain.es/en-us"
+          "https://www.tourspain.es/en-us",
+          "http://apidirectory.connectedliving.gsma.com"
+          "http://apidirectory.connectedliving.gsma.com/*"
       ]
     }
   }

--- a/validator/.textlintrc
+++ b/validator/.textlintrc
@@ -192,7 +192,7 @@
           "https://schema.org/*",
           "http://schema.org/*",
           "https://www.tourspain.es/en-us",
-          "http://apidirectory.connectedliving.gsma.com"
+          "http://apidirectory.connectedliving.gsma.com",
           "http://apidirectory.connectedliving.gsma.com/*"
       ]
     }

--- a/validator/package.json
+++ b/validator/package.json
@@ -55,7 +55,7 @@
 	"scripts": {
 		"lint": "eslint . --cache --fix",
 		"lint:text": "textlint '../README.md' 'README.md' '../specs/*.md' '../specs/**/*.md'",
-		"lint:md": "remark 'README.md' '../specs'",
+		"lint:md": "remark -f 'README.md' '../specs'",
 		"precommit": "lint-staged",
 		"prettier": "prettier --single-quote --trailing-comma es5 --write **/*.js *.js",
 		"prettier:text": "prettier '../*.md' '../specs/*.md' '../specs/**/*.md' --tab-width 4 --print-width 80 --write --prose-wrap always",


### PR DESCRIPTION
This PR does the following:

1) Amends the travis script to run three separate jobs (Python 2.7, Python 3.6  and Docs)
2) Moves the tests from `before_script` to `script` so tests fail rather than error
3) Upgrades the Markdown linting to fail on format errors.
4) Re-run prettier on missing files.
5) Updated `.textlintrc` to ignore some more files to get the build to pass.

### Justification

```text
http://apidirectory.connectedliving.gsma.com
http://apidirectory.connectedliving.gsma.com/api/air-quality-spain
http://apidirectory.connectedliving.gsma.com/api/weather-spain
```

are currently dead - it looks like GSMA are doing some restructuring - maybe we'll need to alter or delete the relevant links, but I've ignored for now so other PRs won't fail incorrectly.