### PR TITLE
Update mkdocs.yml to contain the ThreePhaseAcMeasurement data model

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,8 @@ pages:
       - Introduction           : Device/doc/introduction.md
       - Device                 : Device/Device/doc/spec.md
       - DeviceModel            : Device/DeviceModel/doc/spec.md
+  - Energy:
+      - ThreePhaseAcMeasurement      : Energy/ThreePhaseAcMeasurement/doc/spec.md
   - Environment:
       - Introduction           : Environment/doc/introduction.md
       - AeroAllergenObserved   : Environment/AeroAllergenObserved/doc/spec.md


### PR DESCRIPTION
The ThreePhaseAcMeasurement (pull request #388) was not included to the data models web page since it was missing from the mkdocs.yml file.