### PR TITLE
Make 'operatedBy' Optional (Partial fix for #463)

### DIFF
--- a/specs/UrbanMobility/GtfsStop/doc/spec.md
+++ b/specs/UrbanMobility/GtfsStop/doc/spec.md
@@ -97,7 +97,7 @@ The data model is defined as shown below:
 -   `operatedBy` : Agency that operates this stop.
     -   Attribute type: Relationship. It shall point to an Entity of Type
         [GtfsAgency](../../GtfsAgency/doc/spec.md)
-    -   Mandatory
+    -   Optional
 
 ## Examples
 

--- a/specs/UrbanMobility/GtfsStop/schema.json
+++ b/specs/UrbanMobility/GtfsStop/schema.json
@@ -28,7 +28,6 @@
     "id",
     "type",
     "name",
-    "location",
-    "operatedBy"
+    "location"
   ]
 }


### PR DESCRIPTION
Make 'operatedBy' Optional, since its not mentioned in google's documentation for Stops in GTFS feed