### PR TITLE
Make 'operatedBy' an array of references (Partial fix for #463)

### DIFF
--- a/specs/UrbanMobility/GtfsStop/doc/spec.md
+++ b/specs/UrbanMobility/GtfsStop/doc/spec.md
@@ -95,7 +95,7 @@ The data model is defined as shown below:
     -   Optional
 
 -   `operatedBy` : Agency that operates this stop.
-    -   Attribute type: Relationship. It shall point to an Entity of Type
+    -   Attribute type: List of Relationships. They shall point to an Entity of Type
         [GtfsAgency](../../GtfsAgency/doc/spec.md)
     -   Optional
 

--- a/specs/UrbanMobility/GtfsStop/doc/spec.md
+++ b/specs/UrbanMobility/GtfsStop/doc/spec.md
@@ -97,7 +97,7 @@ The data model is defined as shown below:
 -   `operatedBy` : Agency that operates this stop.
     -   Attribute type: Relationship. It shall point to an Entity of Type
         [GtfsAgency](../../GtfsAgency/doc/spec.md)
-    -   Mandatory
+    -   Optional
 
 ## Examples
 

--- a/specs/UrbanMobility/GtfsStop/example.json
+++ b/specs/UrbanMobility/GtfsStop/example.json
@@ -7,5 +7,5 @@
     "type": "Point",
     "coordinates": [-4.424393,36.716872]
   },
-  "operatedBy": "urn:ngsi-ld:GtfsAgency:Malaga_EMT"
+  "operatedBy": "['urn:ngsi-ld:GtfsAgency:Malaga_EMT']"
 }

--- a/specs/UrbanMobility/GtfsStop/example.json
+++ b/specs/UrbanMobility/GtfsStop/example.json
@@ -7,5 +7,5 @@
     "type": "Point",
     "coordinates": [-4.424393,36.716872]
   },
-  "operatedBy": "['urn:ngsi-ld:GtfsAgency:Malaga_EMT']"
+  "operatedBy": ["urn:ngsi-ld:GtfsAgency:Malaga_EMT"]
 }

--- a/specs/UrbanMobility/GtfsStop/schema.json
+++ b/specs/UrbanMobility/GtfsStop/schema.json
@@ -18,8 +18,10 @@
           "description": "NGSI Entity type"
         },
         "operatedBy": {
-          "type": "string",
-          "format": "uri"
+          "type": "array",
+          "items": { "$ref": "https://fiware.github.io/dataModels/common-schema.json#/definitions/EntityIdentifierType" },
+          "minItems": 0,
+          "uniqueItems": true
         }
       }
     }

--- a/specs/UrbanMobility/GtfsStop/schema.json
+++ b/specs/UrbanMobility/GtfsStop/schema.json
@@ -28,7 +28,6 @@
     "id",
     "type",
     "name",
-    "location",
-    "operatedBy"
+    "location"
   ]
 }


### PR DESCRIPTION
Make 'operatedBy' an array of references, to allow several agencies to be referred as operating in the Stop.
I created separate PR, to ease cherrypicking in case it needs further discussion.