### PR TITLE
Add aggregateRating mapping

### DIFF
--- a/tools/ldcontext_mappings.json
+++ b/tools/ldcontext_mappings.json
@@ -1,6 +1,7 @@
 {
   "name": "http://schema.org/name",
   "alternativeName": "http://schema.org/alternativeName",
+  "aggregateRating": "https://schema.org/aggregateRating",
   "description": "http://schema.org/description",
   "openingHours": "http://schema.org/openingHours",
   "address": "http://schema.org/address",


### PR DESCRIPTION
`aggregateRating` - only used in `specs/Parking/OffStreetParking/schema.json` - states https://schema.org/aggregateRating is normative. This PR adds a mapping to ensure this is the case with the linked-data specification.